### PR TITLE
revise: additions needed for `chainfile`

### DIFF
--- a/omics-coordinate/CHANGELOG.md
+++ b/omics-coordinate/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - This crate was completely reworked. See the pull request for more details
   ([#3](https://github.com/stjude-rust-labs/omics/pull/3)).
+- Implemented `From<String>` for `Contig`
+  ([#4](https://github.com/stjude-rust-labs/omics/pull/4)).
+- Added the `into_start()`, `into_end()`, and `coordinate_at_offset()` methods
+  for `Interval` ([#4](https://github.com/stjude-rust-labs/omics/pull/4)).
+- Added the `into_equivalent_base()` and `into_equivalent_interbase()` methods
+  for interbase and base intervals repectively
+  ([#4](https://github.com/stjude-rust-labs/omics/pull/4)).
 
 ## 0.1.0 - 10-09-2024
 

--- a/omics-coordinate/src/contig.rs
+++ b/omics-coordinate/src/contig.rs
@@ -77,6 +77,12 @@ impl From<&str> for Contig {
     }
 }
 
+impl From<String> for Contig {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
 impl std::ops::Deref for Contig {
     type Target = String;
 

--- a/omics-coordinate/src/interval/base.rs
+++ b/omics-coordinate/src/interval/base.rs
@@ -4,6 +4,7 @@ use crate::base::Coordinate;
 use crate::interval::r#trait;
 use crate::position::Number;
 use crate::system::Base;
+use crate::system::Interbase;
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // Intervals
@@ -14,6 +15,37 @@ use crate::system::Base;
 /// Base intervals consist of two in-base positions. The range is represented by
 /// the interval `[start, end]`.
 pub type Interval = crate::Interval<Base>;
+
+impl Interval {
+    /// Consumes `self` and returns the equivalent interbase interval.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use omics_coordinate::Interval;
+    /// use omics_coordinate::system::Base;
+    /// use omics_coordinate::system::Interbase;
+    ///
+    /// let interval = "seq0:+:1-1000".parse::<Interval<Base>>()?;
+    /// let equivalent = interval.into_equivalent_interbase();
+    ///
+    /// assert_eq!("seq0:+:0-1000".parse::<Interval<Interbase>>()?, equivalent);
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn into_equivalent_interbase(self) -> crate::interval::Interval<Interbase> {
+        let (start, end) = self.into_coordinates();
+
+        // SAFETY: given the rules of how interbase and base coordinate systems
+        // work, this should always unwrap.
+        let start = start.nudge_backward().unwrap();
+        let end = end.nudge_forward().unwrap();
+
+        // SAFETY: since this was previously a valid interbase interval, as long
+        // as the two nudges above succeed, this should always unwrap.
+        crate::interval::Interval::<Interbase>::try_new(start, end).unwrap()
+    }
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // Trait implementations

--- a/omics-coordinate/src/position.rs
+++ b/omics-coordinate/src/position.rs
@@ -115,7 +115,7 @@ pub mod r#trait {
         + std::str::FromStr<Err = Error>
         + CheckedAdd<Number, Output = Self>
         + CheckedSub<Number, Output = Self>
-        + TryFrom<Number, Error = Error>
+        + TryFrom<Number>
         + From<NonZero<Number>>
     where
         Self: Sized,

--- a/omics-coordinate/src/position/interbase.rs
+++ b/omics-coordinate/src/position/interbase.rs
@@ -71,20 +71,6 @@ impl std::str::FromStr for Position {
     }
 }
 
-impl TryFrom<Number> for Position {
-    type Error = Error;
-
-    fn try_from(value: Number) -> std::result::Result<Self, Self::Error> {
-        Ok(Self::new(value))
-    }
-}
-
-impl From<NonZero<Number>> for Position {
-    fn from(value: NonZero<Number>) -> Self {
-        Self::try_from(value.get()).unwrap()
-    }
-}
-
 /// Creates implementations to convert from smaller numbers to a position.
 macro_rules! position_from_smaller_number {
     ($from:ty) => {
@@ -103,6 +89,7 @@ macro_rules! position_from_smaller_number {
 }
 
 #[cfg(feature = "position-u64")]
+position_from_smaller_number!(u64);
 position_from_smaller_number!(u32);
 position_from_smaller_number!(u16);
 position_from_smaller_number!(u8);
@@ -121,7 +108,7 @@ mod tests {
 
     #[test]
     fn try_from_number() {
-        let position: Position<Interbase> = 1u32.try_into().unwrap();
+        let position: Position<Interbase> = 1u32.into();
         assert_eq!(position.get(), 1);
     }
 

--- a/omics/CHANGELOG.md
+++ b/omics/CHANGELOG.md
@@ -7,15 +7,20 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Revise
+
+- Promotes the `position-u64` feature of `omics-coordinate` to the top-level
+  `omics` crate ([#4](https://github.com/stjude-rust-labs/omics/pull/4)).
+
 ## 0.1.0 - 10-09-2024
 
 ### Crate Updates
 
-* `omics-core`: introduced at v0.1.0
+- `omics-core`: introduced at v0.1.0
   ([release](https://github.com/stjude-rust-labs/omics/releases/tag/omics-core-v0.1.0))
-* `omics-coordinate`: introduced at v0.1.0
+- `omics-coordinate`: introduced at v0.1.0
   ([release](https://github.com/stjude-rust-labs/omics/releases/tag/omics-coordinate-v0.1.0))
-* `omics-molecule`: introduced at v0.1.0
+- `omics-molecule`: introduced at v0.1.0
   ([release](https://github.com/stjude-rust-labs/omics/releases/tag/omics-molecule-v0.1.0))
-* `omics-variation`: introduced at v0.1.0
+- `omics-variation`: introduced at v0.1.0
   ([release](https://github.com/stjude-rust-labs/omics/releases/tag/omics-variation-v0.1.0))

--- a/omics/Cargo.toml
+++ b/omics/Cargo.toml
@@ -17,10 +17,15 @@ omics-variation = { path = "../omics-variation", version = "0.1.0", optional = t
 
 [features]
 default = []
+
+# Components
 coordinate = ["dep:omics-coordinate"]
 core = ["dep:omics-core"]
 molecule = ["dep:omics-molecule"]
 variation = ["dep:omics-variation"]
+
+# Functionality
+position-u64 = ["omics-coordinate/position-u64"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
* `Contig`s can now be created from `String`s.
* Added the following methods to `Interval`:
  * `into_start()`
  * `into_end()`
  * `coordinate_at_offset()`
* Adds the `into_equivalent_base()` and `into_equivalent_interbase()` methods for interbase and base intervals respectively.
* Extends the `position-u64` feature to the top-level `omics` crate.