### PR TITLE
revise: better error messages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+_Describe the problem or feature in addition to a link to the issues._
+
+Before submitting this PR, please make sure:
+
+For external contributors:
+
+- [ ] You have not used AI on any parts of this pull request.
+
+For all contributors:
+
+- [ ] You have added a few sentences describing the PR here.
+- [ ] Your code builds clean without any errors or warnings.
+- [ ] You have added tests (when appropriate).
+- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
+- [ ] You have added an entry to the relevant `CHANGELOG.md` (see ["keep a changelog"] for more information).
+- [ ] Your commit messages follow the [conventional commit] style.
+- [ ] Your PR title follows the [conventional commit] style.
+
+[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
+["keep a changelog"]: https://keepachangelog.com/en/1.1.0/

--- a/omics-coordinate/src/position/base.rs
+++ b/omics-coordinate/src/position/base.rs
@@ -139,10 +139,13 @@ mod tests {
     #[test]
     fn from_number() {
         let error: Result<Position<Base>> = 0u32.try_into();
-        assert_eq!(error.unwrap_err(), Error::IncompatibleValue {
-            system: Base::NAME,
-            value: 0,
-        });
+        assert_eq!(
+            error.unwrap_err(),
+            Error::IncompatibleValue {
+                system: Base::NAME,
+                value: 0,
+            }
+        );
 
         let position: Position<Base> = 1u32.try_into().unwrap();
         assert_eq!(position.get(), 1);

--- a/omics-molecule/CHANGELOG.md
+++ b/omics-molecule/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* Used `thiserror` for better error messages and improved existing error
+  messages ([#5](https://github.com/stjude-rust-labs/omics/pull/5)).
+
 ## 0.1.0 - 10-09-2024
 
 ### Added

--- a/omics-molecule/Cargo.toml
+++ b/omics-molecule/Cargo.toml
@@ -12,5 +12,7 @@ rust-version.workspace = true
 [dependencies]
 omics-core = { path = "../omics-core", version = "0.1.0" }
 
+thiserror.workspace = true
+
 [lints]
 workspace = true

--- a/omics-molecule/src/compound/nucleotide/relation.rs
+++ b/omics-molecule/src/compound/nucleotide/relation.rs
@@ -20,33 +20,25 @@ pub mod substitution;
 use omics_core::MISSING_NUCLEOTIDE;
 use omics_core::VARIANT_SEPARATOR;
 pub use substitution::Substitution;
+use thiserror::Error;
 
 use crate::compound::Nucleotide;
 
 /// An error related to a [`Relation`].
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error<N: Nucleotide> {
     /// Attempted to create a relation with no nucleotides.
+    #[error("cannot create a relation with no nucleotides")]
     Empty,
 
     /// A parse error.
+    #[error("parse error: {0}")]
     ParseError(String),
 
     /// A substitution error.
-    Substitution(substitution::Error<N>),
+    #[error(transparent)]
+    Substitution(#[from] substitution::Error<N>),
 }
-
-impl<N: Nucleotide> std::fmt::Display for Error<N> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::Empty => write!(f, "attempted to create a relation with no nucleotides"),
-            Error::ParseError(v) => write!(f, "parse error: {v}"),
-            Error::Substitution(err) => write!(f, "subsitution error: {err}"),
-        }
-    }
-}
-
-impl<N: Nucleotide> std::error::Error for Error<N> {}
 
 /// A [`Result`](std::result::Result) with an [`Error`].
 type Result<T, N> = std::result::Result<T, Error<N>>;
@@ -431,7 +423,7 @@ mod tests {
                 .parse::<Relation<dna::Nucleotide>>()
                 .unwrap_err()
                 .to_string(),
-            "attempted to create a relation with no nucleotides"
+            "cannot create a relation with no nucleotides"
         );
 
         Ok(())

--- a/omics-molecule/src/compound/nucleotide/relation/substitution.rs
+++ b/omics-molecule/src/compound/nucleotide/relation/substitution.rs
@@ -5,26 +5,16 @@ use crate::compound::Nucleotide;
 mod kind;
 
 pub use kind::Kind;
+use thiserror::Error;
 
 /// An error related to a [`Substitution`].
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error<N: Nucleotide> {
     /// Attempted to create a [`Substitution`] with identical reference and
     /// alternate nucleotides.
+    #[error("identical nucleotides in substitution: {0}")]
     Identical(N),
 }
-
-impl<N: Nucleotide> std::fmt::Display for Error<N> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::Identical(nucleotide) => {
-                write!(f, "identical nucleotides for substitution: {nucleotide}")
-            }
-        }
-    }
-}
-
-impl<N: Nucleotide> std::error::Error for Error<N> {}
 
 /// A [`Result`](std::result::Result) with an [`Error<N>`].
 type Result<T, N> = std::result::Result<T, Error<N>>;

--- a/omics-molecule/src/polymer/dna.rs
+++ b/omics-molecule/src/polymer/dna.rs
@@ -3,23 +3,15 @@
 mod nucleotide;
 
 pub use nucleotide::Nucleotide;
+use thiserror::Error;
 
 /// An error related to a [`Molecule`].
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
     /// An error when processing a [`Nucleotide`].
-    NucleotideError(nucleotide::Error),
+    #[error(transparent)]
+    NucleotideError(#[from] nucleotide::Error),
 }
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::NucleotideError(err) => write!(f, "nucleotide error: {err}"),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
 
 /// A molecule representing Deoxyribonucleic Acid, otherwise known as DNA.
 #[derive(Debug)]
@@ -53,12 +45,10 @@ impl Molecule {
     /// let m = "ACGT".parse::<Molecule>()?;
     /// let nucleotides = m.into_inner();
     ///
-    /// assert_eq!(nucleotides, vec![
-    ///     Nucleotide::A,
-    ///     Nucleotide::C,
-    ///     Nucleotide::G,
-    ///     Nucleotide::T,
-    /// ]);
+    /// assert_eq!(
+    ///     nucleotides,
+    ///     vec![Nucleotide::A, Nucleotide::C, Nucleotide::G, Nucleotide::T,]
+    /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -126,6 +116,6 @@ mod tests {
     #[test]
     fn it_fails_to_parse_a_molecule_from_an_invalid_string() {
         let err = "QQQQ".parse::<Molecule>().unwrap_err();
-        assert_eq!(err.to_string(), "nucleotide error: invalid nucleotide: Q");
+        assert_eq!(err.to_string(), "invalid nucleotide `Q`");
     }
 }

--- a/omics-molecule/src/polymer/dna/nucleotide.rs
+++ b/omics-molecule/src/polymer/dna/nucleotide.rs
@@ -1,5 +1,7 @@
 //! Nucleotides in DNA.
 
+use thiserror::Error;
+
 use crate::compound::Kind;
 use crate::compound::nucleotide::Analogous;
 use crate::compound::nucleotide::Transcribe;
@@ -17,46 +19,28 @@ use crate::polymer::rna;
 // the signatures look identical (they will be converted to string differently).
 
 /// An error when parsing a nucleotide.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum ParseError {
     /// An invalid format was attempted to be parsed.
+    #[error("invalid nucleotide format `{0}`")]
     InvalidFormat(String),
 
     /// An invalid nucleotide was attempted to be parsed.
+    #[error("invalid nucleotide `{0}`")]
     InvalidNucleotide(char),
 }
 
-impl std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ParseError::InvalidFormat(value) => write!(f, "invalid format: {value}"),
-            ParseError::InvalidNucleotide(c) => write!(f, "invalid nucleotide: {c}"),
-        }
-    }
-}
-
-impl std::error::Error for ParseError {}
-
 /// An error related to a [`Nucleotide`].
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
     /// An invalid nucleotide was attempted to be created from a [`char`].
+    #[error("invalid nucleotide `{0}`")]
     InvalidNucleotide(char),
 
     /// A parse error.
-    ParseError(ParseError),
+    #[error(transparent)]
+    ParseError(#[from] ParseError),
 }
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::InvalidNucleotide(c) => write!(f, "invalid nucleotide: {c}"),
-            Error::ParseError(err) => write!(f, "parse error: {err}"),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
 
 /// A nucleotide in an DNA context.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -193,13 +177,13 @@ mod tests {
         assert_eq!(Nucleotide::try_from('T')?, Nucleotide::T);
 
         let err = Nucleotide::try_from('u').unwrap_err();
-        assert_eq!(err.to_string(), "invalid nucleotide: u");
+        assert_eq!(err.to_string(), "invalid nucleotide `u`");
 
         let err = Nucleotide::try_from('U').unwrap_err();
-        assert_eq!(err.to_string(), "invalid nucleotide: U");
+        assert_eq!(err.to_string(), "invalid nucleotide `U`");
 
         let err = Nucleotide::try_from('q').unwrap_err();
-        assert_eq!(err.to_string(), "invalid nucleotide: q");
+        assert_eq!(err.to_string(), "invalid nucleotide `q`");
 
         Ok(())
     }
@@ -220,28 +204,28 @@ mod tests {
             err,
             Error::ParseError(ParseError::InvalidFormat(_))
         ));
-        assert_eq!(err.to_string(), "parse error: invalid format: word");
+        assert_eq!(err.to_string(), "invalid nucleotide format `word`");
 
         let err = "q".parse::<Nucleotide>().unwrap_err();
         assert!(matches!(
             err,
             Error::ParseError(ParseError::InvalidNucleotide(_))
         ));
-        assert_eq!(err.to_string(), "parse error: invalid nucleotide: q");
+        assert_eq!(err.to_string(), "invalid nucleotide `q`");
 
         let err = "u".parse::<Nucleotide>().unwrap_err();
         assert!(matches!(
             err,
             Error::ParseError(ParseError::InvalidNucleotide(_))
         ));
-        assert_eq!(err.to_string(), "parse error: invalid nucleotide: u");
+        assert_eq!(err.to_string(), "invalid nucleotide `u`");
 
         let err = "U".parse::<Nucleotide>().unwrap_err();
         assert!(matches!(
             err,
             Error::ParseError(ParseError::InvalidNucleotide(_))
         ));
-        assert_eq!(err.to_string(), "parse error: invalid nucleotide: U");
+        assert_eq!(err.to_string(), "invalid nucleotide `U`");
 
         Ok(())
     }

--- a/omics-molecule/src/polymer/rna.rs
+++ b/omics-molecule/src/polymer/rna.rs
@@ -3,23 +3,15 @@
 mod nucleotide;
 
 pub use nucleotide::Nucleotide;
+use thiserror::Error;
 
 /// An error related to a [`Molecule`].
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
     /// An error when processing a [`Nucleotide`].
-    NucleotideError(nucleotide::Error),
+    #[error(transparent)]
+    NucleotideError(#[from] nucleotide::Error),
 }
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::NucleotideError(err) => write!(f, "nucleotide error: {err}"),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
 
 /// A molecule representing Ribonucleic Acid, otherwise known as RNA.
 #[derive(Debug)]
@@ -53,12 +45,10 @@ impl Molecule {
     /// let m = "ACGU".parse::<Molecule>()?;
     /// let nucleotides = m.into_inner();
     ///
-    /// assert_eq!(nucleotides, vec![
-    ///     Nucleotide::A,
-    ///     Nucleotide::C,
-    ///     Nucleotide::G,
-    ///     Nucleotide::U,
-    /// ]);
+    /// assert_eq!(
+    ///     nucleotides,
+    ///     vec![Nucleotide::A, Nucleotide::C, Nucleotide::G, Nucleotide::U,]
+    /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -126,6 +116,6 @@ mod tests {
     #[test]
     fn it_fails_to_parse_a_molecule_from_an_invalid_string() {
         let err = "QQQQ".parse::<Molecule>().unwrap_err();
-        assert_eq!(err.to_string(), "nucleotide error: invalid nucleotide: Q");
+        assert_eq!(err.to_string(), "invalid nucleotide `Q`");
     }
 }

--- a/omics-variation/CHANGELOG.md
+++ b/omics-variation/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* Used `thiserror` for better error messages and improved existing error
+  messages ([#5](https://github.com/stjude-rust-labs/omics/pull/5)).
+
 ## 0.2.0 - 01-03-2025
 
 ### Crate Updates

--- a/omics-variation/Cargo.toml
+++ b/omics-variation/Cargo.toml
@@ -14,6 +14,8 @@ omics-coordinate = { path = "../omics-coordinate", version = "0.2.0" }
 omics-core = { path = "../omics-core", version = "0.1.0" }
 omics-molecule = { path = "../omics-molecule", version = "0.1.0" }
 
+thiserror.workspace = true
+
 [dev-dependencies]
 anyhow.workspace = true
 

--- a/omics-variation/src/lib.rs
+++ b/omics-variation/src/lib.rs
@@ -3,25 +3,17 @@
 use std::str::FromStr;
 
 use omics_molecule::compound::Nucleotide;
+use thiserror::Error;
 
 pub mod snv;
 
 /// An error related to a [`Variant`].
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
     /// Unsuccessfully attempted to parse a [`Variant`] from a string.
+    #[error("unable to parse a variant from `{0}`")]
     ParseError(String),
 }
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::ParseError(v) => write!(f, "unable to parse a variant from string: {v}"),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
 
 /// A variant.
 #[derive(Debug)]
@@ -85,15 +77,12 @@ mod tests {
     fn it_errors_when_attempting_to_parse_invalid_variants()
     -> Result<(), Box<dyn std::error::Error>> {
         let err = "seq0:1:A".parse::<Variant<dna::Nucleotide>>().unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "unable to parse a variant from string: seq0:1:A"
-        );
+        assert_eq!(err.to_string(), "unable to parse a variant from `seq0:1:A`");
 
         let err = "seq0:1:A:".parse::<Variant<dna::Nucleotide>>().unwrap_err();
         assert_eq!(
             err.to_string(),
-            "unable to parse a variant from string: seq0:1:A:"
+            "unable to parse a variant from `seq0:1:A:`"
         );
 
         let err = "seq0:A:C:1"
@@ -101,7 +90,7 @@ mod tests {
             .unwrap_err();
         assert_eq!(
             err.to_string(),
-            "unable to parse a variant from string: seq0:A:C:1"
+            "unable to parse a variant from `seq0:A:C:1`"
         );
 
         Ok(())


### PR DESCRIPTION
This PR adds better error messages through the use of `thiserror` and refining the language from some messages.

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.


[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/