### PR TITLE
Refactor/interval test clarity 10

### DIFF
--- a/omics-coordinate/CHANGELOG.md
+++ b/omics-coordinate/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `interval::tests::len` duplicated `coordinate_offset` behavior already tested in
+  `negative_strand_offset` while the name implied entity-count semantics. The test
+  now asserts only `count_entities()` coverage: interbase spans and a zero-width
+  interbase interval, plus inclusive in-base counts on both strands
+  ([#10](https://github.com/stjude-rust-labs/omics/issues/10)).
+
 ## 0.4.0 - 03-19-2026
 
 ### Changed

--- a/omics-coordinate/src/interval.rs
+++ b/omics-coordinate/src/interval.rs
@@ -1187,6 +1187,7 @@ mod tests {
     use crate::position::ParseError as PositionParseError;
     use crate::strand::Error as StrandError;
     use crate::strand::ParseError as StrandParseError;
+    use crate::system::Base;
     use crate::system::Interbase;
 
     #[test]
@@ -1474,8 +1475,10 @@ mod tests {
         assert!(interval.coordinate_offset(&coordinate).is_none());
     }
 
+    // count_entities() for interbase vs in-base intervals and both strands.
     #[test]
     fn len() {
+        // Interbase: span length in entities matches start/end distance (positive strand).
         assert_eq!(
             "seq0:+:0-1000"
                 .parse::<Interval<Interbase>>()
@@ -1484,6 +1487,7 @@ mod tests {
             1000
         );
 
+        // Interbase: negative strand (start coordinate is the larger genomic position).
         assert_eq!(
             "seq0:-:1000-0"
                 .parse::<Interval<Interbase>>()
@@ -1491,29 +1495,42 @@ mod tests {
                 .count_entities(),
             1000
         );
-        let interval = "seq0:-:2000-1000".parse::<Interval<Interbase>>().unwrap();
 
-        // Mismatched contigs means the interval does not contain the coordinate.
-        let coordinate = "seq1:-:1000".parse::<Coordinate<Interbase>>().unwrap();
-        assert!(interval.coordinate_offset(&coordinate).is_none());
+        // Interbase: zero-width interval in coordinate space yields zero entities.
+        assert_eq!(
+            "seq0:+:10-10"
+                .parse::<Interval<Interbase>>()
+                .unwrap()
+                .count_entities(),
+            0
+        );
 
-        // Mismatched strands means the interval does not contain the coordinate.
-        let coordinate = "seq0:+:1000".parse::<Coordinate<Interbase>>().unwrap();
-        assert!(interval.coordinate_offset(&coordinate).is_none());
+        // In-base: inclusive range — endpoints both count as entities (positive strand).
+        assert_eq!(
+            "seq0:+:10-20"
+                .parse::<Interval<Base>>()
+                .unwrap()
+                .count_entities(),
+            11
+        );
 
-        // Contained within.
-        let coordinate = "seq0:-:2000".parse::<Coordinate<Interbase>>().unwrap();
-        assert_eq!(interval.coordinate_offset(&coordinate).unwrap(), 0);
+        // In-base: negative strand.
+        assert_eq!(
+            "seq0:-:20-10"
+                .parse::<Interval<Base>>()
+                .unwrap()
+                .count_entities(),
+            11
+        );
 
-        let coordinate = "seq0:-:1000".parse::<Coordinate<Interbase>>().unwrap();
-        assert_eq!(interval.coordinate_offset(&coordinate).unwrap(), 1000);
-
-        // Just outside of range.
-        let coordinate = "seq0:-:999".parse::<Coordinate<Interbase>>().unwrap();
-        assert!(interval.coordinate_offset(&coordinate).is_none());
-
-        let coordinate = "seq0:-:2001".parse::<Coordinate<Interbase>>().unwrap();
-        assert!(interval.coordinate_offset(&coordinate).is_none());
+        // In-base: single position is one entity.
+        assert_eq!(
+            "seq0:+:5-5"
+                .parse::<Interval<Base>>()
+                .unwrap()
+                .count_entities(),
+            1
+        );
     }
 
     #[test]


### PR DESCRIPTION
While reading `omics-coordinate/src/interval.rs`, I noticed that the test named `len` starts with two `count_entities()` checks on interbase intervals for the positive and negative strands, which seems consistent with the test name.

However, the rest of the test uses the same `seq0:-:2000-1000` interval and the same `coordinate_offset` scenarios as the existing `negative_strand_offset` test, so it looks like offset behavior may be covered twice under a name that suggests length or entity-counting semantics.

I may be missing some historical context, but from a readability and maintenance standpoint, it might help to either:

- rename this test so it clearly reflects the offset checks, if that duplication is intentional, or
- remove the duplicated `coordinate_offset` block and expand `count_entities()` coverage instead, for example by adding in-base vs. interbase cases, so that `len` stays focused on length and entity semantics.


For external contributors:

- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see ["keep a changelog"] for more information).
- [ ] Your commit messages follow the [conventional commit] style.
- [ ] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
