### PR TITLE
feat: add `omics-alignment` crate with scoring, CIGAR, and scalar NW/SW

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "omics",
+    "omics-alignment",
     "omics-coordinate",
     "omics-core",
     "omics-molecule",

--- a/omics-alignment/CHANGELOG.md
+++ b/omics-alignment/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+- Scoring infrastructure: `ScoringMatrix` trait, `GapPenalty`, `NucleotideMatrix`,
+  and `Blosum62` substitution matrix.
+- Sequence encoding: `EncodedSequence` with conversions from `omics-molecule`
+  DNA, RNA, and protein types.
+- CIGAR representation: `CigarOp`, `Cigar` with `Display` and `FromStr`.
+- `Alignment` result type with score, CIGAR, and coordinate ranges.
+- Scalar Needleman-Wunsch (global) alignment with affine gap penalties.
+- Scalar Smith-Waterman (local) alignment with affine gap penalties.

--- a/omics-alignment/Cargo.toml
+++ b/omics-alignment/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "omics-alignment"
+version = "0.1.0"
+description = "Sequence alignment primitives and algorithms for the Rust omics ecosystem"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+omics-molecule = { path = "../omics-molecule", version = "0.2.0" }
+
+thiserror.workspace = true
+
+[dev-dependencies]
+anyhow.workspace = true
+
+[lints]
+workspace = true

--- a/omics-alignment/src/cigar.rs
+++ b/omics-alignment/src/cigar.rs
@@ -1,0 +1,320 @@
+//! CIGAR string representation and alignment results.
+//!
+//! Provides [`CigarOp`] for individual alignment operations, [`Cigar`] as a
+//! sequence of operations, and [`Alignment`] as the complete result of a
+//! pairwise alignment including score, CIGAR, and coordinate ranges.
+
+use std::fmt;
+use std::str::FromStr;
+
+use thiserror::Error;
+
+/// An error related to CIGAR parsing.
+#[derive(Error, Debug)]
+pub enum Error {
+    /// An invalid CIGAR operation character was encountered.
+    #[error("invalid CIGAR operation `{0}`")]
+    InvalidOperation(char),
+
+    /// An invalid CIGAR string format was encountered.
+    #[error("invalid CIGAR format `{0}`")]
+    InvalidFormat(String),
+}
+
+/// A single operation in a CIGAR string.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum CigarOp {
+    /// Sequence match (=): residues are identical.
+    SeqMatch(usize),
+
+    /// Sequence mismatch (X): residues differ.
+    SeqMismatch(usize),
+
+    /// Insertion to reference (I): present in query but not reference.
+    Insertion(usize),
+
+    /// Deletion from reference (D): present in reference but not query.
+    Deletion(usize),
+}
+
+impl CigarOp {
+    /// Returns the length of this operation.
+    pub fn len(&self) -> usize {
+        match self {
+            CigarOp::SeqMatch(n)
+            | CigarOp::SeqMismatch(n)
+            | CigarOp::Insertion(n)
+            | CigarOp::Deletion(n) => *n,
+        }
+    }
+
+    /// Returns `true` if this operation has zero length.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the SAM-style character code for this operation.
+    fn code(&self) -> char {
+        match self {
+            CigarOp::SeqMatch(_) => '=',
+            CigarOp::SeqMismatch(_) => 'X',
+            CigarOp::Insertion(_) => 'I',
+            CigarOp::Deletion(_) => 'D',
+        }
+    }
+}
+
+/// A CIGAR string representing the alignment path between two sequences.
+///
+/// # Examples
+///
+/// ```
+/// use omics_alignment::cigar::Cigar;
+/// use omics_alignment::cigar::CigarOp;
+///
+/// let cigar = Cigar::from(vec![
+///     CigarOp::SeqMatch(3),
+///     CigarOp::Insertion(1),
+///     CigarOp::SeqMatch(4),
+/// ]);
+/// assert_eq!(cigar.to_string(), "3=1I4=");
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Cigar(Vec<CigarOp>);
+
+impl Cigar {
+    /// Returns the operations in this CIGAR string.
+    pub fn ops(&self) -> &[CigarOp] {
+        &self.0
+    }
+
+    /// Constructs a CIGAR from a list of single-residue operations, merging
+    /// consecutive operations of the same type.
+    pub(crate) fn from_ops_merged(ops: Vec<CigarOp>) -> Self {
+        let mut merged: Vec<CigarOp> = Vec::new();
+        for op in ops {
+            if op.is_empty() {
+                continue;
+            }
+            if let Some(last) = merged.last_mut() {
+                let merged_op = match (*last, op) {
+                    (CigarOp::SeqMatch(a), CigarOp::SeqMatch(b)) => Some(CigarOp::SeqMatch(a + b)),
+                    (CigarOp::SeqMismatch(a), CigarOp::SeqMismatch(b)) => {
+                        Some(CigarOp::SeqMismatch(a + b))
+                    }
+                    (CigarOp::Insertion(a), CigarOp::Insertion(b)) => {
+                        Some(CigarOp::Insertion(a + b))
+                    }
+                    (CigarOp::Deletion(a), CigarOp::Deletion(b)) => Some(CigarOp::Deletion(a + b)),
+                    _ => None,
+                };
+                if let Some(new_op) = merged_op {
+                    *last = new_op;
+                    continue;
+                }
+            }
+            merged.push(op);
+        }
+        Self(merged)
+    }
+}
+
+impl From<Vec<CigarOp>> for Cigar {
+    fn from(ops: Vec<CigarOp>) -> Self {
+        Self(ops)
+    }
+}
+
+impl fmt::Display for Cigar {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for op in &self.0 {
+            write!(f, "{}{}", op.len(), op.code())?;
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for Cigar {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut ops = Vec::new();
+        let mut num_start = 0;
+
+        for (i, c) in s.char_indices() {
+            if c.is_ascii_digit() {
+                continue;
+            }
+            let len_str = &s[num_start..i];
+            let len: usize = len_str
+                .parse()
+                .map_err(|_| Error::InvalidFormat(s.to_string()))?;
+            let op = match c {
+                '=' => CigarOp::SeqMatch(len),
+                'X' => CigarOp::SeqMismatch(len),
+                'I' => CigarOp::Insertion(len),
+                'D' => CigarOp::Deletion(len),
+                _ => return Err(Error::InvalidOperation(c)),
+            };
+            ops.push(op);
+            num_start = i + 1;
+        }
+
+        if num_start != s.len() {
+            return Err(Error::InvalidFormat(s.to_string()));
+        }
+
+        Ok(Self(ops))
+    }
+}
+
+/// The result of a pairwise sequence alignment.
+///
+/// Contains the alignment score, CIGAR string, and the coordinate ranges in
+/// both the query and reference sequences.
+///
+/// # Examples
+///
+/// ```
+/// use omics_alignment::cigar::Alignment;
+/// use omics_alignment::cigar::Cigar;
+/// use omics_alignment::cigar::CigarOp;
+///
+/// let alignment = Alignment::new(10, Cigar::from(vec![CigarOp::SeqMatch(5)]), 0, 5, 0, 5);
+/// assert_eq!(alignment.score(), 10);
+/// assert_eq!(alignment.cigar().to_string(), "5=");
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Alignment {
+    /// The alignment score.
+    score: i32,
+
+    /// The CIGAR string.
+    cigar: Cigar,
+
+    /// The start position in the query (0-based, inclusive).
+    query_start: usize,
+
+    /// The end position in the query (0-based, exclusive).
+    query_end: usize,
+
+    /// The start position in the reference (0-based, inclusive).
+    reference_start: usize,
+
+    /// The end position in the reference (0-based, exclusive).
+    reference_end: usize,
+}
+
+impl Alignment {
+    /// Creates a new alignment result.
+    pub fn new(
+        score: i32,
+        cigar: Cigar,
+        query_start: usize,
+        query_end: usize,
+        reference_start: usize,
+        reference_end: usize,
+    ) -> Self {
+        Self {
+            score,
+            cigar,
+            query_start,
+            query_end,
+            reference_start,
+            reference_end,
+        }
+    }
+
+    /// Returns the alignment score.
+    pub fn score(&self) -> i32 {
+        self.score
+    }
+
+    /// Returns the CIGAR string.
+    pub fn cigar(&self) -> &Cigar {
+        &self.cigar
+    }
+
+    /// Returns the start position in the query (0-based, inclusive).
+    pub fn query_start(&self) -> usize {
+        self.query_start
+    }
+
+    /// Returns the end position in the query (0-based, exclusive).
+    pub fn query_end(&self) -> usize {
+        self.query_end
+    }
+
+    /// Returns the start position in the reference (0-based, inclusive).
+    pub fn reference_start(&self) -> usize {
+        self.reference_start
+    }
+
+    /// Returns the end position in the reference (0-based, exclusive).
+    pub fn reference_end(&self) -> usize {
+        self.reference_end
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_displays_cigar_strings() {
+        let cigar = Cigar::from(vec![
+            CigarOp::SeqMatch(3),
+            CigarOp::Insertion(2),
+            CigarOp::SeqMatch(4),
+            CigarOp::Deletion(1),
+        ]);
+        assert_eq!(cigar.to_string(), "3=2I4=1D");
+    }
+
+    #[test]
+    fn it_parses_cigar_strings() -> Result<(), Box<dyn std::error::Error>> {
+        let cigar = "3=2I4=1D".parse::<Cigar>()?;
+        assert_eq!(
+            cigar.ops(),
+            &[
+                CigarOp::SeqMatch(3),
+                CigarOp::Insertion(2),
+                CigarOp::SeqMatch(4),
+                CigarOp::Deletion(1),
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn it_round_trips_cigar_strings() -> Result<(), Box<dyn std::error::Error>> {
+        let original = "5=3X2I1D4=";
+        let cigar = original.parse::<Cigar>()?;
+        assert_eq!(cigar.to_string(), original);
+        Ok(())
+    }
+
+    #[test]
+    fn it_merges_consecutive_operations() {
+        let ops = vec![
+            CigarOp::SeqMatch(1),
+            CigarOp::SeqMatch(1),
+            CigarOp::SeqMatch(1),
+            CigarOp::Insertion(1),
+            CigarOp::Insertion(1),
+            CigarOp::SeqMismatch(1),
+        ];
+        let cigar = Cigar::from_ops_merged(ops);
+        assert_eq!(cigar.to_string(), "3=2I1X");
+    }
+
+    #[test]
+    fn it_rejects_invalid_cigar_operations() {
+        let err = "3Z".parse::<Cigar>().unwrap_err();
+        assert!(matches!(err, Error::InvalidOperation('Z')));
+    }
+}

--- a/omics-alignment/src/lib.rs
+++ b/omics-alignment/src/lib.rs
@@ -1,0 +1,21 @@
+//! Sequence alignment primitives and algorithms.
+//!
+//! This crate provides foundational types and algorithms for pairwise sequence
+//! alignment in the `omics` ecosystem, including:
+//!
+//! - **Scoring**: substitution matrices ([`score::NucleotideMatrix`],
+//!   [`score::Blosum62`]) and affine gap penalty models ([`score::GapPenalty`])
+//! - **Encoding**: integer-encoded sequence representations
+//!   ([`sequence::EncodedSequence`]) with conversions from `omics-molecule`
+//!   DNA, RNA, and protein types
+//! - **Results**: CIGAR string representation ([`cigar::Cigar`]) and alignment
+//!   result type ([`cigar::Alignment`])
+//! - **Algorithms**: scalar Needleman-Wunsch ([`needleman_wunsch`]) for global
+//!   alignment and Smith-Waterman ([`smith_waterman`]) for local alignment,
+//!   both with affine gap penalties and full traceback
+
+pub mod cigar;
+pub mod needleman_wunsch;
+pub mod score;
+pub mod sequence;
+pub mod smith_waterman;

--- a/omics-alignment/src/needleman_wunsch.rs
+++ b/omics-alignment/src/needleman_wunsch.rs
@@ -1,0 +1,315 @@
+//! Needleman-Wunsch global alignment with affine gap penalties.
+//!
+//! Computes the optimal global alignment between two sequences using
+//! the Gotoh variant of the Needleman-Wunsch algorithm with separate
+//! gap-open and gap-extend costs.
+//!
+//! # Examples
+//!
+//! ```
+//! use omics_alignment::needleman_wunsch;
+//! use omics_alignment::score::GapPenalty;
+//! use omics_alignment::score::NucleotideMatrix;
+//! use omics_alignment::sequence::EncodedSequence;
+//! use omics_molecule::polymer::dna;
+//!
+//! let query = "ACGTACGT".parse::<dna::Molecule>()?;
+//! let reference = "ACGTACGT".parse::<dna::Molecule>()?;
+//!
+//! let result = needleman_wunsch::align(
+//!     &EncodedSequence::from(&query),
+//!     &EncodedSequence::from(&reference),
+//!     &NucleotideMatrix::new(1, -1),
+//!     &GapPenalty::affine(-2, -1),
+//! );
+//!
+//! assert_eq!(result.score(), 8);
+//! assert_eq!(result.cigar().to_string(), "8=");
+//!
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+
+use crate::cigar::Alignment;
+use crate::cigar::Cigar;
+use crate::cigar::CigarOp;
+use crate::score::GapPenalty;
+use crate::score::ScoringMatrix;
+use crate::sequence::EncodedSequence;
+
+/// Sentinel value representing negative infinity for DP initialization.
+const NEG_INF: i32 = i32::MIN / 2;
+
+/// Traceback direction in the H matrix.
+#[derive(Clone, Copy)]
+enum TraceH {
+    /// Came from diagonal (match/mismatch).
+    Diagonal,
+    /// Came from E matrix (gap in query = deletion).
+    FromE,
+    /// Came from F matrix (gap in reference = insertion).
+    FromF,
+}
+
+/// Traceback direction in the E or F gap matrices.
+#[derive(Clone, Copy)]
+enum TraceGap {
+    /// Gap was opened from the H matrix.
+    Open,
+    /// Gap was extended from the same gap matrix.
+    Extend,
+}
+
+/// Computes the optimal global alignment using Needleman-Wunsch with affine
+/// gap penalties.
+///
+/// Returns an [`Alignment`] spanning the full length of both sequences.
+pub fn align<M: ScoringMatrix>(
+    query: &EncodedSequence,
+    reference: &EncodedSequence,
+    matrix: &M,
+    gap_penalty: &GapPenalty,
+) -> Alignment {
+    let m = query.len();
+    let n = reference.len();
+
+    if m == 0 && n == 0 {
+        return Alignment::new(0, Cigar::from(vec![]), 0, 0, 0, 0);
+    }
+    if m == 0 {
+        return Alignment::new(
+            gap_penalty.cost(n),
+            Cigar::from(vec![CigarOp::Deletion(n)]),
+            0,
+            0,
+            0,
+            n,
+        );
+    }
+    if n == 0 {
+        return Alignment::new(
+            gap_penalty.cost(m),
+            Cigar::from(vec![CigarOp::Insertion(m)]),
+            0,
+            m,
+            0,
+            0,
+        );
+    }
+
+    let rows = m + 1;
+    let cols = n + 1;
+
+    let mut h = vec![vec![0i32; cols]; rows];
+    let mut e = vec![vec![NEG_INF; cols]; rows];
+    let mut f = vec![vec![NEG_INF; cols]; rows];
+
+    let mut trace_h = vec![vec![TraceH::Diagonal; cols]; rows];
+    let mut trace_e = vec![vec![TraceGap::Open; cols]; rows];
+    let mut trace_f = vec![vec![TraceGap::Open; cols]; rows];
+
+    // Initialize first column (gaps in reference).
+    for i in 1..rows {
+        h[i][0] = gap_penalty.cost(i);
+        f[i][0] = h[i][0];
+        trace_h[i][0] = TraceH::FromF;
+    }
+
+    // Initialize first row (gaps in query).
+    for j in 1..cols {
+        h[0][j] = gap_penalty.cost(j);
+        e[0][j] = h[0][j];
+        trace_h[0][j] = TraceH::FromE;
+    }
+
+    // Fill the DP matrices.
+    for i in 1..rows {
+        for j in 1..cols {
+            // E: horizontal gap (gap in query = deletion).
+            let e_extend = e[i][j - 1] + gap_penalty.extend();
+            let e_open = h[i][j - 1] + gap_penalty.open();
+            if e_extend >= e_open {
+                e[i][j] = e_extend;
+                trace_e[i][j] = TraceGap::Extend;
+            } else {
+                e[i][j] = e_open;
+                trace_e[i][j] = TraceGap::Open;
+            }
+
+            // F: vertical gap (gap in reference = insertion).
+            let f_extend = f[i - 1][j] + gap_penalty.extend();
+            let f_open = h[i - 1][j] + gap_penalty.open();
+            if f_extend >= f_open {
+                f[i][j] = f_extend;
+                trace_f[i][j] = TraceGap::Extend;
+            } else {
+                f[i][j] = f_open;
+                trace_f[i][j] = TraceGap::Open;
+            }
+
+            // H: best of diagonal, E, or F.
+            let diag = h[i - 1][j - 1] + matrix.score(query.get(i - 1), reference.get(j - 1));
+            h[i][j] = diag;
+            trace_h[i][j] = TraceH::Diagonal;
+
+            if e[i][j] > h[i][j] {
+                h[i][j] = e[i][j];
+                trace_h[i][j] = TraceH::FromE;
+            }
+            if f[i][j] > h[i][j] {
+                h[i][j] = f[i][j];
+                trace_h[i][j] = TraceH::FromF;
+            }
+        }
+    }
+
+    let score = h[m][n];
+    let cigar = traceback(query, reference, m, n, &trace_h, &trace_e, &trace_f);
+
+    Alignment::new(score, cigar, 0, m, 0, n)
+}
+
+/// Performs traceback from `(i, j)` to `(0, 0)` to reconstruct the CIGAR.
+fn traceback(
+    query: &EncodedSequence,
+    reference: &EncodedSequence,
+    start_i: usize,
+    start_j: usize,
+    trace_h: &[Vec<TraceH>],
+    trace_e: &[Vec<TraceGap>],
+    trace_f: &[Vec<TraceGap>],
+) -> Cigar {
+    /// Which DP matrix the traceback is currently following.
+    enum State {
+        /// In the H matrix.
+        H,
+        /// In the E matrix (horizontal gap).
+        E,
+        /// In the F matrix (vertical gap).
+        F,
+    }
+
+    let mut ops = Vec::new();
+    let mut i = start_i;
+    let mut j = start_j;
+    let mut state = State::H;
+
+    while i > 0 || j > 0 {
+        match state {
+            State::H => {
+                if i == 0 {
+                    ops.push(CigarOp::Deletion(j));
+                    break;
+                }
+                if j == 0 {
+                    ops.push(CigarOp::Insertion(i));
+                    break;
+                }
+                match trace_h[i][j] {
+                    TraceH::Diagonal => {
+                        if query.get(i - 1) == reference.get(j - 1) {
+                            ops.push(CigarOp::SeqMatch(1));
+                        } else {
+                            ops.push(CigarOp::SeqMismatch(1));
+                        }
+                        i -= 1;
+                        j -= 1;
+                    }
+                    TraceH::FromE => state = State::E,
+                    TraceH::FromF => state = State::F,
+                }
+            }
+            State::E => {
+                ops.push(CigarOp::Deletion(1));
+                match trace_e[i][j] {
+                    TraceGap::Extend => j -= 1,
+                    TraceGap::Open => {
+                        j -= 1;
+                        state = State::H;
+                    }
+                }
+            }
+            State::F => {
+                ops.push(CigarOp::Insertion(1));
+                match trace_f[i][j] {
+                    TraceGap::Extend => i -= 1,
+                    TraceGap::Open => {
+                        i -= 1;
+                        state = State::H;
+                    }
+                }
+            }
+        }
+    }
+
+    ops.reverse();
+    Cigar::from_ops_merged(ops)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::score::NucleotideMatrix;
+
+    /// Helper to align two DNA strings.
+    fn align_dna(q: &str, r: &str, m: i32, mm: i32, go: i32, ge: i32) -> Alignment {
+        let qm = q.parse::<omics_molecule::polymer::dna::Molecule>().unwrap();
+        let rm = r.parse::<omics_molecule::polymer::dna::Molecule>().unwrap();
+        align(
+            &EncodedSequence::from(&qm),
+            &EncodedSequence::from(&rm),
+            &NucleotideMatrix::new(m, mm),
+            &GapPenalty::affine(go, ge),
+        )
+    }
+
+    #[test]
+    fn it_aligns_identical_sequences() {
+        let result = align_dna("ACGT", "ACGT", 1, -1, -2, -1);
+        assert_eq!(result.score(), 4);
+        assert_eq!(result.cigar().to_string(), "4=");
+    }
+
+    #[test]
+    fn it_aligns_sequences_with_a_mismatch() {
+        let result = align_dna("ACGT", "ACGA", 1, -1, -2, -1);
+        assert_eq!(result.score(), 2);
+        assert_eq!(result.cigar().to_string(), "3=1X");
+    }
+
+    #[test]
+    fn it_aligns_sequences_with_a_deletion() {
+        let result = align_dna("ACGT", "ACGGT", 2, -1, -3, -1);
+        let cigar = result.cigar().to_string();
+        assert!(cigar.contains('D') || cigar.contains('I'));
+    }
+
+    #[test]
+    fn it_aligns_sequences_with_an_insertion() {
+        let result = align_dna("ACGGT", "ACGT", 2, -1, -3, -1);
+        let cigar = result.cigar().to_string();
+        assert!(cigar.contains('I') || cigar.contains('D'));
+    }
+
+    #[test]
+    fn it_handles_empty_query() {
+        let result = align_dna("", "ACGT", 1, -1, -2, -1);
+        assert_eq!(result.cigar().to_string(), "4D");
+        assert_eq!(result.score(), -5);
+    }
+
+    #[test]
+    fn it_handles_empty_reference() {
+        let result = align_dna("ACGT", "", 1, -1, -2, -1);
+        assert_eq!(result.cigar().to_string(), "4I");
+        assert_eq!(result.score(), -5);
+    }
+
+    #[test]
+    fn it_spans_full_sequences() {
+        let result = align_dna("ACGT", "ACGT", 1, -1, -2, -1);
+        assert_eq!(result.query_start(), 0);
+        assert_eq!(result.query_end(), 4);
+        assert_eq!(result.reference_start(), 0);
+        assert_eq!(result.reference_end(), 4);
+    }
+}

--- a/omics-alignment/src/score.rs
+++ b/omics-alignment/src/score.rs
@@ -1,0 +1,232 @@
+//! Scoring matrices and gap penalty models.
+//!
+//! Provides the [`ScoringMatrix`] trait for abstracting over substitution
+//! matrices, concrete implementations for nucleotide and protein alignment, and
+//! the [`GapPenalty`] type for affine gap penalty models.
+
+/// A substitution scoring matrix for pairwise alignment.
+///
+/// Implementations map pairs of encoded residue indices to integer scores.
+/// Residue indices are assigned by
+/// [`EncodedSequence`](crate::sequence::EncodedSequence) during encoding (e.g.,
+/// A=0, C=1, G=2, T=3 for DNA).
+pub trait ScoringMatrix {
+    /// Returns the substitution score for aligning residue `a` against residue
+    /// `b`, where both are encoded residue indices.
+    fn score(&self, a: u8, b: u8) -> i32;
+}
+
+/// An affine gap penalty model.
+///
+/// A gap of length *n* costs `open + (n - 1) * extend`, where
+/// [`open`](Self::open) is the cost of the first gap position and
+/// [`extend`](Self::extend) is the cost of each subsequent position. Both
+/// values should be negative (or zero).
+///
+/// # Examples
+///
+/// ```
+/// use omics_alignment::score::GapPenalty;
+///
+/// // Affine gap: opening costs -11, extension costs -1.
+/// let affine = GapPenalty::affine(-11, -1);
+/// assert_eq!(affine.cost(1), -11);
+/// assert_eq!(affine.cost(3), -13);
+///
+/// // Linear gap: every position costs -2.
+/// let linear = GapPenalty::linear(-2);
+/// assert_eq!(linear.cost(1), -2);
+/// assert_eq!(linear.cost(3), -6);
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct GapPenalty {
+    /// The cost of opening a gap (first position).
+    open: i32,
+
+    /// The cost of extending an existing gap (each additional position).
+    extend: i32,
+}
+
+impl GapPenalty {
+    /// Creates an affine gap penalty with the given open and extend costs.
+    pub fn affine(open: i32, extend: i32) -> Self {
+        Self { open, extend }
+    }
+
+    /// Creates a linear gap penalty where every gap position has the same cost.
+    pub fn linear(penalty: i32) -> Self {
+        Self {
+            open: penalty,
+            extend: penalty,
+        }
+    }
+
+    /// Returns the open cost.
+    pub fn open(&self) -> i32 {
+        self.open
+    }
+
+    /// Returns the extend cost.
+    pub fn extend(&self) -> i32 {
+        self.extend
+    }
+
+    /// Returns the total cost of a gap of length `n`.
+    pub fn cost(&self, n: usize) -> i32 {
+        if n == 0 {
+            return 0;
+        }
+        self.open + (n as i32 - 1) * self.extend
+    }
+}
+
+/// A simple nucleotide scoring matrix using match/mismatch scores.
+///
+/// # Examples
+///
+/// ```
+/// use omics_alignment::score::NucleotideMatrix;
+/// use omics_alignment::score::ScoringMatrix;
+///
+/// let matrix = NucleotideMatrix::new(1, -1);
+/// assert_eq!(matrix.score(0, 0), 1); // match
+/// assert_eq!(matrix.score(0, 1), -1); // mismatch
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct NucleotideMatrix {
+    /// Score awarded for matching residues.
+    match_score: i32,
+
+    /// Score penalized for mismatching residues.
+    mismatch_score: i32,
+}
+
+impl NucleotideMatrix {
+    /// Creates a new nucleotide scoring matrix.
+    pub fn new(match_score: i32, mismatch_score: i32) -> Self {
+        Self {
+            match_score,
+            mismatch_score,
+        }
+    }
+}
+
+impl ScoringMatrix for NucleotideMatrix {
+    fn score(&self, a: u8, b: u8) -> i32 {
+        if a == b {
+            self.match_score
+        } else {
+            self.mismatch_score
+        }
+    }
+}
+
+/// The BLOSUM62 substitution matrix for protein sequence alignment.
+///
+/// Residues are indexed in standard BLOSUM order:
+/// A=0, R=1, N=2, D=3, C=4, Q=5, E=6, G=7, H=8, I=9,
+/// L=10, K=11, M=12, F=13, P=14, S=15, T=16, W=17, Y=18, V=19.
+///
+/// # Examples
+///
+/// ```
+/// use omics_alignment::score::Blosum62;
+/// use omics_alignment::score::ScoringMatrix;
+///
+/// let matrix = Blosum62;
+/// assert_eq!(matrix.score(0, 0), 4); // A-A
+/// assert_eq!(matrix.score(4, 4), 9); // C-C
+/// assert_eq!(matrix.score(17, 17), 11); // W-W
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct Blosum62;
+
+impl ScoringMatrix for Blosum62 {
+    fn score(&self, a: u8, b: u8) -> i32 {
+        BLOSUM62_DATA[a as usize][b as usize]
+    }
+}
+
+/// Raw BLOSUM62 data indexed as [row][col] in standard amino acid order.
+//
+// Source: Henikoff & Henikoff (1992), PNAS 89(22):10915-10919.
+// Order: A R N D C Q E G H I L K M F P S T W Y V
+#[rustfmt::skip]
+const BLOSUM62_DATA: [[i32; 20]; 20] = [
+//   A   R   N   D   C   Q   E   G   H   I   L   K   M   F   P   S   T   W   Y   V
+    [ 4, -1, -2, -2,  0, -1, -1,  0, -2, -1, -1, -1, -1, -2, -1,  1,  0, -3, -2,  0], // A
+    [-1,  5,  0, -2, -3,  1,  0, -2,  0, -3, -2,  2, -1, -3, -2, -1, -1, -3, -2, -3], // R
+    [-2,  0,  6,  1, -3,  0,  0,  0,  1, -3, -3,  0, -2, -3, -2,  1,  0, -4, -2, -3], // N
+    [-2, -2,  1,  6, -3,  0,  2, -1, -1, -3, -4, -1, -3, -3, -1,  0, -1, -4, -3, -3], // D
+    [ 0, -3, -3, -3,  9, -3, -4, -3, -3, -1, -1, -3, -1, -2, -3, -1, -1, -2, -2, -1], // C
+    [-1,  1,  0,  0, -3,  5,  2, -2,  0, -3, -2,  1,  0, -3, -1,  0, -1, -2, -1, -2], // Q
+    [-1,  0,  0,  2, -4,  2,  5, -2,  0, -3, -3,  1, -2, -3, -1,  0, -1, -3, -2, -2], // E
+    [ 0, -2,  0, -1, -3, -2, -2,  6, -2, -4, -4, -2, -3, -3, -2,  0, -2, -2, -3, -3], // G
+    [-2,  0,  1, -1, -3,  0,  0, -2,  8, -3, -3, -1, -2, -1, -2, -1, -2, -2,  2, -3], // H
+    [-1, -3, -3, -3, -1, -3, -3, -4, -3,  4,  2, -3,  1,  0, -3, -2, -1, -3, -1,  3], // I
+    [-1, -2, -3, -4, -1, -2, -3, -4, -3,  2,  4, -2,  2,  0, -3, -2, -1, -2, -1,  1], // L
+    [-1,  2,  0, -1, -3,  1,  1, -2, -1, -3, -2,  5, -1, -3, -1,  0, -1, -3, -2, -2], // K
+    [-1, -1, -2, -3, -1,  0, -2, -3, -2,  1,  2, -1,  5,  0, -2, -1, -1, -1, -1,  1], // M
+    [-2, -3, -3, -3, -2, -3, -3, -3, -1,  0,  0, -3,  0,  6, -4, -2, -2,  1,  3, -1], // F
+    [-1, -2, -2, -1, -3, -1, -1, -2, -2, -3, -3, -1, -2, -4,  7, -1, -1, -4, -3, -2], // P
+    [ 1, -1,  1,  0, -1,  0,  0,  0, -1, -2, -2,  0, -1, -2, -1,  4,  1, -3, -2, -2], // S
+    [ 0, -1,  0, -1, -1, -1, -1, -2, -2, -1, -1, -1, -1, -2, -1,  1,  5, -2, -2,  0], // T
+    [-3, -3, -4, -4, -2, -2, -3, -2, -2, -3, -2, -3, -1,  1, -4, -3, -2, 11,  2, -3], // W
+    [-2, -2, -2, -3, -2, -1, -2, -3,  2, -1, -1, -2, -1,  3, -3, -2, -2,  2,  7, -1], // Y
+    [ 0, -3, -3, -3, -1, -2, -2, -3, -3,  3,  1, -2,  1, -1, -2, -2,  0, -3, -1,  4], // V
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_calculates_affine_gap_costs() {
+        let gap = GapPenalty::affine(-11, -1);
+        assert_eq!(gap.cost(0), 0);
+        assert_eq!(gap.cost(1), -11);
+        assert_eq!(gap.cost(2), -12);
+        assert_eq!(gap.cost(5), -15);
+    }
+
+    #[test]
+    fn it_calculates_linear_gap_costs() {
+        let gap = GapPenalty::linear(-2);
+        assert_eq!(gap.cost(0), 0);
+        assert_eq!(gap.cost(1), -2);
+        assert_eq!(gap.cost(3), -6);
+    }
+
+    #[test]
+    fn it_scores_nucleotide_matches_and_mismatches() {
+        let m = NucleotideMatrix::new(2, -1);
+        assert_eq!(m.score(0, 0), 2);
+        assert_eq!(m.score(0, 1), -1);
+        assert_eq!(m.score(3, 3), 2);
+    }
+
+    #[test]
+    fn it_returns_correct_blosum62_diagonal_values() {
+        let m = Blosum62;
+        assert_eq!(m.score(0, 0), 4); // A-A
+        assert_eq!(m.score(4, 4), 9); // C-C
+        assert_eq!(m.score(8, 8), 8); // H-H
+        assert_eq!(m.score(17, 17), 11); // W-W
+    }
+
+    #[test]
+    fn it_returns_symmetric_blosum62_values() {
+        let m = Blosum62;
+        for a in 0..20u8 {
+            for b in 0..20u8 {
+                assert_eq!(m.score(a, b), m.score(b, a));
+            }
+        }
+    }
+}

--- a/omics-alignment/src/sequence.rs
+++ b/omics-alignment/src/sequence.rs
@@ -1,0 +1,166 @@
+//! Encoded sequence representations for alignment.
+//!
+//! [`EncodedSequence`] provides a compact integer-encoded representation of
+//! biological sequences suitable for use with scoring matrices. Conversions
+//! from `omics-molecule` DNA, RNA, and protein types are provided.
+
+use omics_molecule::polymer::dna;
+use omics_molecule::polymer::protein;
+use omics_molecule::polymer::rna;
+
+/// A sequence of residues encoded as compact integer indices.
+///
+/// Each residue is represented as a `u8` index into a scoring matrix. The
+/// encoding is determined by the source molecule type:
+///
+/// - **DNA**: A=0, C=1, G=2, T=3
+/// - **RNA**: A=0, C=1, G=2, U=3
+/// - **Protein**: BLOSUM order — A=0, R=1, N=2, D=3, C=4, Q=5, E=6, G=7, H=8,
+///   I=9, L=10, K=11, M=12, F=13, P=14, S=15, T=16, W=17, Y=18, V=19
+///
+/// # Examples
+///
+/// ```
+/// use omics_alignment::sequence::EncodedSequence;
+/// use omics_molecule::polymer::dna;
+///
+/// let mol = "ACGT".parse::<dna::Molecule>()?;
+/// let seq = EncodedSequence::from(&mol);
+/// assert_eq!(seq.len(), 4);
+/// assert_eq!(seq.get(0), 0); // A
+/// assert_eq!(seq.get(2), 2); // G
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct EncodedSequence {
+    /// The encoded residue data.
+    data: Vec<u8>,
+}
+
+impl EncodedSequence {
+    /// Returns the length of the sequence.
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Returns `true` if the sequence is empty.
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// Returns the encoded residue at the given index.
+    pub fn get(&self, index: usize) -> u8 {
+        self.data[index]
+    }
+}
+
+impl From<&dna::Molecule> for EncodedSequence {
+    fn from(mol: &dna::Molecule) -> Self {
+        let data = mol
+            .inner()
+            .iter()
+            .map(|n| match n {
+                dna::Nucleotide::A => 0,
+                dna::Nucleotide::C => 1,
+                dna::Nucleotide::G => 2,
+                dna::Nucleotide::T => 3,
+            })
+            .collect();
+        Self { data }
+    }
+}
+
+impl From<&rna::Molecule> for EncodedSequence {
+    fn from(mol: &rna::Molecule) -> Self {
+        let data = mol
+            .inner()
+            .iter()
+            .map(|n| match n {
+                rna::Nucleotide::A => 0,
+                rna::Nucleotide::C => 1,
+                rna::Nucleotide::G => 2,
+                rna::Nucleotide::U => 3,
+            })
+            .collect();
+        Self { data }
+    }
+}
+
+impl From<&protein::Molecule> for EncodedSequence {
+    fn from(mol: &protein::Molecule) -> Self {
+        let data = mol
+            .inner()
+            .iter()
+            .map(|aa| match aa {
+                protein::AminoAcid::A => 0,
+                protein::AminoAcid::R => 1,
+                protein::AminoAcid::N => 2,
+                protein::AminoAcid::D => 3,
+                protein::AminoAcid::C => 4,
+                protein::AminoAcid::Q => 5,
+                protein::AminoAcid::E => 6,
+                protein::AminoAcid::G => 7,
+                protein::AminoAcid::H => 8,
+                protein::AminoAcid::I => 9,
+                protein::AminoAcid::L => 10,
+                protein::AminoAcid::K => 11,
+                protein::AminoAcid::M => 12,
+                protein::AminoAcid::F => 13,
+                protein::AminoAcid::P => 14,
+                protein::AminoAcid::S => 15,
+                protein::AminoAcid::T => 16,
+                protein::AminoAcid::W => 17,
+                protein::AminoAcid::Y => 18,
+                protein::AminoAcid::V => 19,
+            })
+            .collect();
+        Self { data }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_encodes_dna_sequences() -> Result<(), Box<dyn std::error::Error>> {
+        let mol = "ACGT".parse::<dna::Molecule>()?;
+        let seq = EncodedSequence::from(&mol);
+        assert_eq!(seq.len(), 4);
+        assert_eq!(seq.get(0), 0);
+        assert_eq!(seq.get(1), 1);
+        assert_eq!(seq.get(2), 2);
+        assert_eq!(seq.get(3), 3);
+        Ok(())
+    }
+
+    #[test]
+    fn it_encodes_rna_sequences() -> Result<(), Box<dyn std::error::Error>> {
+        let mol = "ACGU".parse::<rna::Molecule>()?;
+        let seq = EncodedSequence::from(&mol);
+        assert_eq!(seq.len(), 4);
+        assert_eq!(seq.get(3), 3); // U
+        Ok(())
+    }
+
+    #[test]
+    fn it_encodes_protein_sequences() -> Result<(), Box<dyn std::error::Error>> {
+        let mol = "ARNDCQE".parse::<protein::Molecule>()?;
+        let seq = EncodedSequence::from(&mol);
+        assert_eq!(seq.len(), 7);
+        assert_eq!(seq.get(0), 0); // A
+        assert_eq!(seq.get(1), 1); // R
+        assert_eq!(seq.get(5), 5); // Q (BLOSUM order)
+        assert_eq!(seq.get(6), 6); // E (BLOSUM order)
+        Ok(())
+    }
+
+    #[test]
+    fn it_reports_empty_sequences() {
+        let mol = dna::Molecule::from(vec![]);
+        let seq = EncodedSequence::from(&mol);
+        assert!(seq.is_empty());
+        assert_eq!(seq.len(), 0);
+    }
+}

--- a/omics-alignment/src/smith_waterman.rs
+++ b/omics-alignment/src/smith_waterman.rs
@@ -1,0 +1,303 @@
+//! Smith-Waterman local alignment with affine gap penalties.
+//!
+//! Computes the optimal local alignment between two sequences using
+//! the Smith-Waterman algorithm with affine gap penalties. The local
+//! alignment identifies the highest-scoring subsequence pair, ignoring
+//! poorly-matching flanking regions.
+//!
+//! # Examples
+//!
+//! ```
+//! use omics_alignment::score::GapPenalty;
+//! use omics_alignment::score::NucleotideMatrix;
+//! use omics_alignment::sequence::EncodedSequence;
+//! use omics_alignment::smith_waterman;
+//! use omics_molecule::polymer::dna;
+//!
+//! let query = "AAACGTAAAA".parse::<dna::Molecule>()?;
+//! let reference = "TTCGTTTT".parse::<dna::Molecule>()?;
+//!
+//! let result = smith_waterman::align(
+//!     &EncodedSequence::from(&query),
+//!     &EncodedSequence::from(&reference),
+//!     &NucleotideMatrix::new(2, -1),
+//!     &GapPenalty::affine(-3, -1),
+//! );
+//!
+//! assert!(result.score() > 0);
+//!
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+
+use crate::cigar::Alignment;
+use crate::cigar::Cigar;
+use crate::cigar::CigarOp;
+use crate::score::GapPenalty;
+use crate::score::ScoringMatrix;
+use crate::sequence::EncodedSequence;
+
+/// Sentinel value representing negative infinity for DP initialization.
+const NEG_INF: i32 = i32::MIN / 2;
+
+/// Traceback direction in the H matrix.
+#[derive(Clone, Copy, PartialEq)]
+enum TraceH {
+    /// Cell is zero (local alignment boundary).
+    End,
+    /// Came from diagonal (match/mismatch).
+    Diagonal,
+    /// Came from E matrix (gap in query = deletion).
+    FromE,
+    /// Came from F matrix (gap in reference = insertion).
+    FromF,
+}
+
+/// Traceback direction in the E or F gap matrices.
+#[derive(Clone, Copy)]
+enum TraceGap {
+    /// Gap was opened from the H matrix.
+    Open,
+    /// Gap was extended from the same gap matrix.
+    Extend,
+}
+
+/// Computes the optimal local alignment using Smith-Waterman with affine gap
+/// penalties.
+///
+/// Returns an [`Alignment`] covering only the highest-scoring local region.
+pub fn align<M: ScoringMatrix>(
+    query: &EncodedSequence,
+    reference: &EncodedSequence,
+    matrix: &M,
+    gap_penalty: &GapPenalty,
+) -> Alignment {
+    let m = query.len();
+    let n = reference.len();
+
+    if m == 0 || n == 0 {
+        return Alignment::new(0, Cigar::from(vec![]), 0, 0, 0, 0);
+    }
+
+    let rows = m + 1;
+    let cols = n + 1;
+
+    let mut h = vec![vec![0i32; cols]; rows];
+    let mut e = vec![vec![NEG_INF; cols]; rows];
+    let mut f = vec![vec![NEG_INF; cols]; rows];
+
+    let mut trace_h = vec![vec![TraceH::End; cols]; rows];
+    let mut trace_e = vec![vec![TraceGap::Open; cols]; rows];
+    let mut trace_f = vec![vec![TraceGap::Open; cols]; rows];
+
+    let mut max_score = 0i32;
+    let mut max_i = 0usize;
+    let mut max_j = 0usize;
+
+    // Fill the DP matrices (first row and column remain zero).
+    for i in 1..rows {
+        for j in 1..cols {
+            // E: horizontal gap (gap in query = deletion).
+            let e_extend = e[i][j - 1] + gap_penalty.extend();
+            let e_open = h[i][j - 1] + gap_penalty.open();
+            if e_extend >= e_open {
+                e[i][j] = e_extend;
+                trace_e[i][j] = TraceGap::Extend;
+            } else {
+                e[i][j] = e_open;
+                trace_e[i][j] = TraceGap::Open;
+            }
+
+            // F: vertical gap (gap in reference = insertion).
+            let f_extend = f[i - 1][j] + gap_penalty.extend();
+            let f_open = h[i - 1][j] + gap_penalty.open();
+            if f_extend >= f_open {
+                f[i][j] = f_extend;
+                trace_f[i][j] = TraceGap::Extend;
+            } else {
+                f[i][j] = f_open;
+                trace_f[i][j] = TraceGap::Open;
+            }
+
+            // H: best of zero, diagonal, E, or F.
+            let diag = h[i - 1][j - 1] + matrix.score(query.get(i - 1), reference.get(j - 1));
+            let mut best = 0;
+            let mut trace = TraceH::End;
+
+            if diag > best {
+                best = diag;
+                trace = TraceH::Diagonal;
+            }
+            if e[i][j] > best {
+                best = e[i][j];
+                trace = TraceH::FromE;
+            }
+            if f[i][j] > best {
+                best = f[i][j];
+                trace = TraceH::FromF;
+            }
+
+            h[i][j] = best;
+            trace_h[i][j] = trace;
+
+            if best > max_score {
+                max_score = best;
+                max_i = i;
+                max_j = j;
+            }
+        }
+    }
+
+    if max_score == 0 {
+        return Alignment::new(0, Cigar::from(vec![]), 0, 0, 0, 0);
+    }
+
+    let (cigar, end_i, end_j) =
+        traceback(query, reference, max_i, max_j, &trace_h, &trace_e, &trace_f);
+
+    Alignment::new(max_score, cigar, end_i, max_i, end_j, max_j)
+}
+
+/// Performs traceback from `(start_i, start_j)` backward until a zero cell,
+/// returning the CIGAR and the start coordinates.
+fn traceback(
+    query: &EncodedSequence,
+    reference: &EncodedSequence,
+    start_i: usize,
+    start_j: usize,
+    trace_h: &[Vec<TraceH>],
+    trace_e: &[Vec<TraceGap>],
+    trace_f: &[Vec<TraceGap>],
+) -> (Cigar, usize, usize) {
+    /// Which DP matrix the traceback is currently following.
+    enum State {
+        /// In the H matrix.
+        H,
+        /// In the E matrix (horizontal gap).
+        E,
+        /// In the F matrix (vertical gap).
+        F,
+    }
+
+    let mut ops = Vec::new();
+    let mut i = start_i;
+    let mut j = start_j;
+    let mut state = State::H;
+
+    loop {
+        match state {
+            State::H => match trace_h[i][j] {
+                TraceH::End => break,
+                TraceH::Diagonal => {
+                    if query.get(i - 1) == reference.get(j - 1) {
+                        ops.push(CigarOp::SeqMatch(1));
+                    } else {
+                        ops.push(CigarOp::SeqMismatch(1));
+                    }
+                    i -= 1;
+                    j -= 1;
+                }
+                TraceH::FromE => state = State::E,
+                TraceH::FromF => state = State::F,
+            },
+            State::E => {
+                ops.push(CigarOp::Deletion(1));
+                match trace_e[i][j] {
+                    TraceGap::Extend => j -= 1,
+                    TraceGap::Open => {
+                        j -= 1;
+                        state = State::H;
+                    }
+                }
+            }
+            State::F => {
+                ops.push(CigarOp::Insertion(1));
+                match trace_f[i][j] {
+                    TraceGap::Extend => i -= 1,
+                    TraceGap::Open => {
+                        i -= 1;
+                        state = State::H;
+                    }
+                }
+            }
+        }
+    }
+
+    ops.reverse();
+    (Cigar::from_ops_merged(ops), i, j)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::score::Blosum62;
+    use crate::score::NucleotideMatrix;
+
+    /// Helper to locally align two DNA strings.
+    fn align_dna(q: &str, r: &str, m: i32, mm: i32, go: i32, ge: i32) -> Alignment {
+        let qm = q.parse::<omics_molecule::polymer::dna::Molecule>().unwrap();
+        let rm = r.parse::<omics_molecule::polymer::dna::Molecule>().unwrap();
+        align(
+            &EncodedSequence::from(&qm),
+            &EncodedSequence::from(&rm),
+            &NucleotideMatrix::new(m, mm),
+            &GapPenalty::affine(go, ge),
+        )
+    }
+
+    #[test]
+    fn it_aligns_identical_sequences() {
+        let result = align_dna("ACGT", "ACGT", 2, -1, -3, -1);
+        assert_eq!(result.score(), 8);
+        assert_eq!(result.cigar().to_string(), "4=");
+    }
+
+    #[test]
+    fn it_finds_local_alignment_in_flanking_noise() {
+        let result = align_dna("AAACGTAAA", "TTTCGTTT", 2, -1, -3, -1);
+        assert!(result.score() >= 6); // at least the "CGT" match
+        assert!(result.cigar().to_string().contains('='));
+    }
+
+    #[test]
+    fn it_returns_zero_for_completely_dissimilar_sequences() {
+        // With match=1, mismatch=-2, these are always negative when paired.
+        let result = align_dna("AAAA", "CCCC", 1, -2, -3, -1);
+        assert_eq!(result.score(), 0);
+    }
+
+    #[test]
+    fn it_handles_empty_sequences() {
+        let result = align_dna("", "ACGT", 1, -1, -2, -1);
+        assert_eq!(result.score(), 0);
+
+        let result = align_dna("ACGT", "", 1, -1, -2, -1);
+        assert_eq!(result.score(), 0);
+    }
+
+    #[test]
+    fn it_aligns_proteins_with_blosum62() {
+        let q = "MKWVTFISLLFLFSSAYS"
+            .parse::<omics_molecule::polymer::protein::Molecule>()
+            .unwrap();
+        let r = "MKWVTFISLLFSSAYS"
+            .parse::<omics_molecule::polymer::protein::Molecule>()
+            .unwrap();
+        let result = align(
+            &EncodedSequence::from(&q),
+            &EncodedSequence::from(&r),
+            &Blosum62,
+            &GapPenalty::affine(-11, -1),
+        );
+        assert!(result.score() > 0);
+        assert!(!result.cigar().ops().is_empty());
+    }
+
+    #[test]
+    fn it_reports_correct_alignment_coordinates() {
+        let result = align_dna("AAACGTAAA", "TTTCGTTTT", 2, -1, -3, -1);
+        assert!(result.query_start() <= result.query_end());
+        assert!(result.reference_start() <= result.reference_end());
+        assert!(result.query_end() <= 9);
+        assert!(result.reference_end() <= 9);
+    }
+}

--- a/omics-molecule/src/compound.rs
+++ b/omics-molecule/src/compound.rs
@@ -1,7 +1,9 @@
 //! Compounds.
 
+pub mod amino_acid;
 mod kind;
 pub mod nucleotide;
 
+pub use amino_acid::AminoAcid;
 pub use kind::Kind;
 pub use nucleotide::Nucleotide;

--- a/omics-molecule/src/compound/amino_acid.rs
+++ b/omics-molecule/src/compound/amino_acid.rs
@@ -1,0 +1,36 @@
+//! Amino acids.
+
+/// A classification of an amino acid based on the biochemical properties of its
+/// side chain.
+///
+/// This classification follows the standard Lehninger grouping of the twenty
+/// canonical amino acids by side-chain chemistry.
+#[derive(Debug, Eq, PartialEq)]
+pub enum Classification {
+    /// A nonpolar amino acid with an aliphatic side chain (Gly, Ala, Val, Leu,
+    /// Ile, Pro, Met).
+    NonpolarAliphatic,
+
+    /// A nonpolar amino acid with an aromatic side chain (Phe, Trp, Tyr).
+    Aromatic,
+
+    /// A polar amino acid with an uncharged side chain at physiological pH
+    /// (Ser, Thr, Cys, Asn, Gln).
+    PolarUncharged,
+
+    /// An amino acid with a positively charged side chain at physiological pH
+    /// (Lys, Arg, His).
+    PositivelyCharged,
+
+    /// An amino acid with a negatively charged side chain at physiological pH
+    /// (Asp, Glu).
+    NegativelyCharged,
+}
+
+/// A marker trait that denotes a type of amino acid.
+pub trait AminoAcid:
+    std::fmt::Debug + std::fmt::Display + Copy + Eq + PartialEq + std::str::FromStr
+{
+    /// Gets the [`Classification`] for a given [`AminoAcid`].
+    fn classification(&self) -> Classification;
+}

--- a/omics-molecule/src/polymer.rs
+++ b/omics-molecule/src/polymer.rs
@@ -1,4 +1,5 @@
 //! A substance comprised of repeating subunits of macromolecules.
 
 pub mod dna;
+pub mod protein;
 pub mod rna;

--- a/omics-molecule/src/polymer/protein.rs
+++ b/omics-molecule/src/polymer/protein.rs
@@ -1,0 +1,110 @@
+//! Protein.
+
+mod amino_acid;
+
+pub use amino_acid::AminoAcid;
+use thiserror::Error;
+
+/// An error related to a [`Molecule`].
+#[derive(Error, Debug)]
+pub enum Error {
+    /// An error when processing an [`AminoAcid`].
+    #[error(transparent)]
+    AminoAcidError(#[from] amino_acid::Error),
+}
+
+/// A molecule representing a protein, which is a polymer of amino acids.
+///
+/// # Examples
+///
+/// ```
+/// use omics_molecule::polymer::protein::Molecule;
+///
+/// let m = "MKWVTFISLLFLFSSAYS".parse::<Molecule>()?;
+/// assert_eq!(m.inner().len(), 18);
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Debug)]
+pub struct Molecule(Vec<AminoAcid>);
+
+impl Molecule {
+    /// Gets the inner [`Vec<AminoAcid>`] by reference.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use omics_molecule::polymer::protein::Molecule;
+    ///
+    /// let m = "ARNDCEQGHILKMFPSTWYV".parse::<Molecule>()?;
+    /// assert_eq!(m.inner().len(), 20);
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn inner(&self) -> &Vec<AminoAcid> {
+        self.0.as_ref()
+    }
+
+    /// Consumes the [`Molecule`] and returns the inner [`Vec<AminoAcid>`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use omics_molecule::polymer::protein::AminoAcid;
+    /// use omics_molecule::polymer::protein::Molecule;
+    ///
+    /// let m = "ACDE".parse::<Molecule>()?;
+    /// let amino_acids = m.into_inner();
+    ///
+    /// assert_eq!(
+    ///     amino_acids,
+    ///     vec![AminoAcid::A, AminoAcid::C, AminoAcid::D, AminoAcid::E,]
+    /// );
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn into_inner(self) -> Vec<AminoAcid> {
+        self.0
+    }
+}
+
+impl From<Vec<AminoAcid>> for Molecule {
+    fn from(v: Vec<AminoAcid>) -> Self {
+        Self(v)
+    }
+}
+
+impl std::str::FromStr for Molecule {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.chars()
+            .map(|c| AminoAcid::try_from(c).map_err(Error::AminoAcidError))
+            .collect::<Result<Vec<_>, Error>>()
+            .map(Self::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_creates_a_molecule_from_a_vec_of_amino_acids() {
+        let amino_acids = vec![AminoAcid::M, AminoAcid::K, AminoAcid::W, AminoAcid::V];
+
+        let protein = Molecule::from(amino_acids);
+        assert_eq!(protein.inner().len(), 4);
+    }
+
+    #[test]
+    fn it_parses_a_molecule_from_a_valid_string() -> Result<(), Box<dyn std::error::Error>> {
+        Ok("ARNDCEQGHILKMFPSTWYV".parse::<Molecule>().map(|_| ())?)
+    }
+
+    #[test]
+    fn it_fails_to_parse_a_molecule_from_an_invalid_string() {
+        let err = "ARJX".parse::<Molecule>().unwrap_err();
+        assert_eq!(err.to_string(), "invalid amino acid `J`");
+    }
+}

--- a/omics-molecule/src/polymer/protein/amino_acid.rs
+++ b/omics-molecule/src/polymer/protein/amino_acid.rs
@@ -1,0 +1,417 @@
+//! Amino acids in proteins.
+
+use thiserror::Error;
+
+use crate::compound::amino_acid::Classification;
+
+/// An error when parsing an amino acid.
+#[derive(Error, Debug)]
+pub enum ParseError {
+    /// An invalid format was attempted to be parsed.
+    #[error("invalid amino acid format `{0}`")]
+    InvalidFormat(String),
+
+    /// An invalid amino acid was attempted to be parsed.
+    #[error("invalid amino acid `{0}`")]
+    InvalidAminoAcid(char),
+}
+
+/// An error related to an [`AminoAcid`].
+#[derive(Error, Debug)]
+pub enum Error {
+    /// An invalid amino acid was attempted to be created from a [`char`].
+    #[error("invalid amino acid `{0}`")]
+    InvalidAminoAcid(char),
+
+    /// A parse error.
+    #[error(transparent)]
+    ParseError(#[from] ParseError),
+}
+
+/// An amino acid in a protein context.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum AminoAcid {
+    /// Alanine.
+    A,
+
+    /// Arginine.
+    R,
+
+    /// Asparagine.
+    N,
+
+    /// Aspartic acid.
+    D,
+
+    /// Cysteine.
+    C,
+
+    /// Glutamic acid.
+    E,
+
+    /// Glutamine.
+    Q,
+
+    /// Glycine.
+    G,
+
+    /// Histidine.
+    H,
+
+    /// Isoleucine.
+    I,
+
+    /// Leucine.
+    L,
+
+    /// Lysine.
+    K,
+
+    /// Methionine.
+    M,
+
+    /// Phenylalanine.
+    F,
+
+    /// Proline.
+    P,
+
+    /// Serine.
+    S,
+
+    /// Threonine.
+    T,
+
+    /// Tryptophan.
+    W,
+
+    /// Tyrosine.
+    Y,
+
+    /// Valine.
+    V,
+}
+
+impl crate::compound::AminoAcid for AminoAcid {
+    fn classification(&self) -> Classification {
+        match self {
+            AminoAcid::G
+            | AminoAcid::A
+            | AminoAcid::V
+            | AminoAcid::L
+            | AminoAcid::I
+            | AminoAcid::P
+            | AminoAcid::M => Classification::NonpolarAliphatic,
+            AminoAcid::F | AminoAcid::W | AminoAcid::Y => Classification::Aromatic,
+            AminoAcid::S | AminoAcid::T | AminoAcid::C | AminoAcid::N | AminoAcid::Q => {
+                Classification::PolarUncharged
+            }
+            AminoAcid::K | AminoAcid::R | AminoAcid::H => Classification::PositivelyCharged,
+            AminoAcid::D | AminoAcid::E => Classification::NegativelyCharged,
+        }
+    }
+}
+
+impl std::fmt::Display for AminoAcid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AminoAcid::A => write!(f, "A"),
+            AminoAcid::R => write!(f, "R"),
+            AminoAcid::N => write!(f, "N"),
+            AminoAcid::D => write!(f, "D"),
+            AminoAcid::C => write!(f, "C"),
+            AminoAcid::E => write!(f, "E"),
+            AminoAcid::Q => write!(f, "Q"),
+            AminoAcid::G => write!(f, "G"),
+            AminoAcid::H => write!(f, "H"),
+            AminoAcid::I => write!(f, "I"),
+            AminoAcid::L => write!(f, "L"),
+            AminoAcid::K => write!(f, "K"),
+            AminoAcid::M => write!(f, "M"),
+            AminoAcid::F => write!(f, "F"),
+            AminoAcid::P => write!(f, "P"),
+            AminoAcid::S => write!(f, "S"),
+            AminoAcid::T => write!(f, "T"),
+            AminoAcid::W => write!(f, "W"),
+            AminoAcid::Y => write!(f, "Y"),
+            AminoAcid::V => write!(f, "V"),
+        }
+    }
+}
+
+impl TryFrom<char> for AminoAcid {
+    type Error = Error;
+
+    fn try_from(c: char) -> Result<Self, Self::Error> {
+        match c {
+            'A' | 'a' => Ok(AminoAcid::A),
+            'R' | 'r' => Ok(AminoAcid::R),
+            'N' | 'n' => Ok(AminoAcid::N),
+            'D' | 'd' => Ok(AminoAcid::D),
+            'C' | 'c' => Ok(AminoAcid::C),
+            'E' | 'e' => Ok(AminoAcid::E),
+            'Q' | 'q' => Ok(AminoAcid::Q),
+            'G' | 'g' => Ok(AminoAcid::G),
+            'H' | 'h' => Ok(AminoAcid::H),
+            'I' | 'i' => Ok(AminoAcid::I),
+            'L' | 'l' => Ok(AminoAcid::L),
+            'K' | 'k' => Ok(AminoAcid::K),
+            'M' | 'm' => Ok(AminoAcid::M),
+            'F' | 'f' => Ok(AminoAcid::F),
+            'P' | 'p' => Ok(AminoAcid::P),
+            'S' | 's' => Ok(AminoAcid::S),
+            'T' | 't' => Ok(AminoAcid::T),
+            'W' | 'w' => Ok(AminoAcid::W),
+            'Y' | 'y' => Ok(AminoAcid::Y),
+            'V' | 'v' => Ok(AminoAcid::V),
+            _ => Err(Error::InvalidAminoAcid(c)),
+        }
+    }
+}
+
+impl std::str::FromStr for AminoAcid {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() != 1 {
+            return Err(Error::ParseError(ParseError::InvalidFormat(s.to_string())));
+        }
+
+        // SAFETY: we just ensured that the length is one, so this must unwrap.
+        let c = s.chars().next().unwrap();
+
+        match c {
+            'A' | 'a' => Ok(AminoAcid::A),
+            'R' | 'r' => Ok(AminoAcid::R),
+            'N' | 'n' => Ok(AminoAcid::N),
+            'D' | 'd' => Ok(AminoAcid::D),
+            'C' | 'c' => Ok(AminoAcid::C),
+            'E' | 'e' => Ok(AminoAcid::E),
+            'Q' | 'q' => Ok(AminoAcid::Q),
+            'G' | 'g' => Ok(AminoAcid::G),
+            'H' | 'h' => Ok(AminoAcid::H),
+            'I' | 'i' => Ok(AminoAcid::I),
+            'L' | 'l' => Ok(AminoAcid::L),
+            'K' | 'k' => Ok(AminoAcid::K),
+            'M' | 'm' => Ok(AminoAcid::M),
+            'F' | 'f' => Ok(AminoAcid::F),
+            'P' | 'p' => Ok(AminoAcid::P),
+            'S' | 's' => Ok(AminoAcid::S),
+            'T' | 't' => Ok(AminoAcid::T),
+            'W' | 'w' => Ok(AminoAcid::W),
+            'Y' | 'y' => Ok(AminoAcid::Y),
+            'V' | 'v' => Ok(AminoAcid::V),
+            _ => Err(Error::ParseError(ParseError::InvalidAminoAcid(c))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_correctly_classifies_nonpolar_aliphatic_amino_acids() {
+        use crate::compound::AminoAcid as _;
+
+        assert_eq!(
+            AminoAcid::G.classification(),
+            Classification::NonpolarAliphatic
+        );
+        assert_eq!(
+            AminoAcid::A.classification(),
+            Classification::NonpolarAliphatic
+        );
+        assert_eq!(
+            AminoAcid::V.classification(),
+            Classification::NonpolarAliphatic
+        );
+        assert_eq!(
+            AminoAcid::L.classification(),
+            Classification::NonpolarAliphatic
+        );
+        assert_eq!(
+            AminoAcid::I.classification(),
+            Classification::NonpolarAliphatic
+        );
+        assert_eq!(
+            AminoAcid::P.classification(),
+            Classification::NonpolarAliphatic
+        );
+        assert_eq!(
+            AminoAcid::M.classification(),
+            Classification::NonpolarAliphatic
+        );
+    }
+
+    #[test]
+    fn it_correctly_classifies_aromatic_amino_acids() {
+        use crate::compound::AminoAcid as _;
+
+        assert_eq!(AminoAcid::F.classification(), Classification::Aromatic);
+        assert_eq!(AminoAcid::W.classification(), Classification::Aromatic);
+        assert_eq!(AminoAcid::Y.classification(), Classification::Aromatic);
+    }
+
+    #[test]
+    fn it_correctly_classifies_polar_uncharged_amino_acids() {
+        use crate::compound::AminoAcid as _;
+
+        assert_eq!(
+            AminoAcid::S.classification(),
+            Classification::PolarUncharged
+        );
+        assert_eq!(
+            AminoAcid::T.classification(),
+            Classification::PolarUncharged
+        );
+        assert_eq!(
+            AminoAcid::C.classification(),
+            Classification::PolarUncharged
+        );
+        assert_eq!(
+            AminoAcid::N.classification(),
+            Classification::PolarUncharged
+        );
+        assert_eq!(
+            AminoAcid::Q.classification(),
+            Classification::PolarUncharged
+        );
+    }
+
+    #[test]
+    fn it_correctly_classifies_positively_charged_amino_acids() {
+        use crate::compound::AminoAcid as _;
+
+        assert_eq!(
+            AminoAcid::K.classification(),
+            Classification::PositivelyCharged
+        );
+        assert_eq!(
+            AminoAcid::R.classification(),
+            Classification::PositivelyCharged
+        );
+        assert_eq!(
+            AminoAcid::H.classification(),
+            Classification::PositivelyCharged
+        );
+    }
+
+    #[test]
+    fn it_correctly_classifies_negatively_charged_amino_acids() {
+        use crate::compound::AminoAcid as _;
+
+        assert_eq!(
+            AminoAcid::D.classification(),
+            Classification::NegativelyCharged
+        );
+        assert_eq!(
+            AminoAcid::E.classification(),
+            Classification::NegativelyCharged
+        );
+    }
+
+    #[test]
+    fn it_correctly_serializes_amino_acids() {
+        assert_eq!(AminoAcid::A.to_string(), "A");
+        assert_eq!(AminoAcid::R.to_string(), "R");
+        assert_eq!(AminoAcid::N.to_string(), "N");
+        assert_eq!(AminoAcid::D.to_string(), "D");
+        assert_eq!(AminoAcid::C.to_string(), "C");
+        assert_eq!(AminoAcid::E.to_string(), "E");
+        assert_eq!(AminoAcid::Q.to_string(), "Q");
+        assert_eq!(AminoAcid::G.to_string(), "G");
+        assert_eq!(AminoAcid::H.to_string(), "H");
+        assert_eq!(AminoAcid::I.to_string(), "I");
+        assert_eq!(AminoAcid::L.to_string(), "L");
+        assert_eq!(AminoAcid::K.to_string(), "K");
+        assert_eq!(AminoAcid::M.to_string(), "M");
+        assert_eq!(AminoAcid::F.to_string(), "F");
+        assert_eq!(AminoAcid::P.to_string(), "P");
+        assert_eq!(AminoAcid::S.to_string(), "S");
+        assert_eq!(AminoAcid::T.to_string(), "T");
+        assert_eq!(AminoAcid::W.to_string(), "W");
+        assert_eq!(AminoAcid::Y.to_string(), "Y");
+        assert_eq!(AminoAcid::V.to_string(), "V");
+    }
+
+    #[test]
+    fn it_correctly_creates_an_amino_acid_from_a_char() -> Result<(), Box<dyn std::error::Error>> {
+        assert_eq!(AminoAcid::try_from('A')?, AminoAcid::A);
+        assert_eq!(AminoAcid::try_from('a')?, AminoAcid::A);
+        assert_eq!(AminoAcid::try_from('R')?, AminoAcid::R);
+        assert_eq!(AminoAcid::try_from('r')?, AminoAcid::R);
+        assert_eq!(AminoAcid::try_from('N')?, AminoAcid::N);
+        assert_eq!(AminoAcid::try_from('n')?, AminoAcid::N);
+        assert_eq!(AminoAcid::try_from('D')?, AminoAcid::D);
+        assert_eq!(AminoAcid::try_from('d')?, AminoAcid::D);
+        assert_eq!(AminoAcid::try_from('C')?, AminoAcid::C);
+        assert_eq!(AminoAcid::try_from('c')?, AminoAcid::C);
+        assert_eq!(AminoAcid::try_from('E')?, AminoAcid::E);
+        assert_eq!(AminoAcid::try_from('e')?, AminoAcid::E);
+        assert_eq!(AminoAcid::try_from('Q')?, AminoAcid::Q);
+        assert_eq!(AminoAcid::try_from('q')?, AminoAcid::Q);
+        assert_eq!(AminoAcid::try_from('G')?, AminoAcid::G);
+        assert_eq!(AminoAcid::try_from('g')?, AminoAcid::G);
+        assert_eq!(AminoAcid::try_from('H')?, AminoAcid::H);
+        assert_eq!(AminoAcid::try_from('h')?, AminoAcid::H);
+        assert_eq!(AminoAcid::try_from('I')?, AminoAcid::I);
+        assert_eq!(AminoAcid::try_from('i')?, AminoAcid::I);
+        assert_eq!(AminoAcid::try_from('L')?, AminoAcid::L);
+        assert_eq!(AminoAcid::try_from('l')?, AminoAcid::L);
+        assert_eq!(AminoAcid::try_from('K')?, AminoAcid::K);
+        assert_eq!(AminoAcid::try_from('k')?, AminoAcid::K);
+        assert_eq!(AminoAcid::try_from('M')?, AminoAcid::M);
+        assert_eq!(AminoAcid::try_from('m')?, AminoAcid::M);
+        assert_eq!(AminoAcid::try_from('F')?, AminoAcid::F);
+        assert_eq!(AminoAcid::try_from('f')?, AminoAcid::F);
+        assert_eq!(AminoAcid::try_from('P')?, AminoAcid::P);
+        assert_eq!(AminoAcid::try_from('p')?, AminoAcid::P);
+        assert_eq!(AminoAcid::try_from('S')?, AminoAcid::S);
+        assert_eq!(AminoAcid::try_from('s')?, AminoAcid::S);
+        assert_eq!(AminoAcid::try_from('T')?, AminoAcid::T);
+        assert_eq!(AminoAcid::try_from('t')?, AminoAcid::T);
+        assert_eq!(AminoAcid::try_from('W')?, AminoAcid::W);
+        assert_eq!(AminoAcid::try_from('w')?, AminoAcid::W);
+        assert_eq!(AminoAcid::try_from('Y')?, AminoAcid::Y);
+        assert_eq!(AminoAcid::try_from('y')?, AminoAcid::Y);
+        assert_eq!(AminoAcid::try_from('V')?, AminoAcid::V);
+        assert_eq!(AminoAcid::try_from('v')?, AminoAcid::V);
+
+        let err = AminoAcid::try_from('Z').unwrap_err();
+        assert_eq!(err.to_string(), "invalid amino acid `Z`");
+
+        let err = AminoAcid::try_from('1').unwrap_err();
+        assert_eq!(err.to_string(), "invalid amino acid `1`");
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_correctly_deserializes_amino_acids() -> Result<(), Box<dyn std::error::Error>> {
+        assert_eq!("A".parse::<AminoAcid>()?, AminoAcid::A);
+        assert_eq!("a".parse::<AminoAcid>()?, AminoAcid::A);
+        assert_eq!("R".parse::<AminoAcid>()?, AminoAcid::R);
+        assert_eq!("r".parse::<AminoAcid>()?, AminoAcid::R);
+        assert_eq!("W".parse::<AminoAcid>()?, AminoAcid::W);
+        assert_eq!("w".parse::<AminoAcid>()?, AminoAcid::W);
+        assert_eq!("V".parse::<AminoAcid>()?, AminoAcid::V);
+        assert_eq!("v".parse::<AminoAcid>()?, AminoAcid::V);
+
+        let err = "word".parse::<AminoAcid>().unwrap_err();
+        assert!(matches!(
+            err,
+            Error::ParseError(ParseError::InvalidFormat(_))
+        ));
+        assert_eq!(err.to_string(), "invalid amino acid format `word`");
+
+        let err = "Z".parse::<AminoAcid>().unwrap_err();
+        assert!(matches!(
+            err,
+            Error::ParseError(ParseError::InvalidAminoAcid(_))
+        ));
+        assert_eq!(err.to_string(), "invalid amino acid `Z`");
+
+        Ok(())
+    }
+}

--- a/omics/Cargo.toml
+++ b/omics/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+omics-alignment = { path = "../omics-alignment", version = "0.1.0", optional = true }
 omics-core = { path = "../omics-core", version = "0.1.0", optional = true }
 omics-coordinate = { path = "../omics-coordinate", version = "0.4.0", optional = true }
 omics-molecule = { path = "../omics-molecule", version = "0.2.0", optional = true }
@@ -19,6 +20,7 @@ omics-variation = { path = "../omics-variation", version = "0.3.0", optional = t
 default = []
 
 # Components
+alignment = ["dep:omics-alignment"]
 coordinate = ["dep:omics-coordinate"]
 core = ["dep:omics-core"]
 molecule = ["dep:omics-molecule"]

--- a/omics/src/lib.rs
+++ b/omics/src/lib.rs
@@ -2,6 +2,9 @@
 //!
 //! See each individual module's documentation for more information.
 
+#[cfg(feature = "alignment")]
+#[doc(inline)]
+pub use omics_alignment as alignment;
 #[cfg(feature = "coordinate")]
 #[doc(inline)]
 pub use omics_coordinate as coordinate;


### PR DESCRIPTION
## Summary

Introduces the `omics-alignment` crate — a new workspace member providing foundational sequence alignment infrastructure and reference scalar algorithm implementations for the `omics` ecosystem.

**Depends on**: #12 (protein sequence primitives for `EncodedSequence::from(&protein::Molecule)`)

### Scoring infrastructure (`score.rs`)
- **`ScoringMatrix` trait** — generic abstraction over substitution matrices
- **`NucleotideMatrix`** — simple match/mismatch scoring for DNA/RNA alignment
- **`Blosum62`** — the standard 20×20 protein substitution matrix (Henikoff & Henikoff, 1992) stored as a const array indexed in standard BLOSUM order
- **`GapPenalty`** — affine gap penalty model (`open + (n-1) * extend`), also supports linear gaps as a special case

### Sequence encoding (`sequence.rs`)
- **`EncodedSequence`** — compact `u8`-indexed residue representation with `From` conversions for `dna::Molecule`, `rna::Molecule`, and `protein::Molecule` from `omics-molecule`
- Protein encoding maps to BLOSUM62 index order (A=0, R=1, ... V=19)

### Alignment results (`cigar.rs`)
- **`CigarOp`** — enum for `=`/`X`/`I`/`D` operations with `Display` and `FromStr` on `Cigar`
- **`Alignment`** — result type with score, CIGAR, and query/reference coordinate ranges
- Consecutive operations are merged during traceback for compact output

### Algorithms
- **`needleman_wunsch::align`** — scalar global alignment with the Gotoh affine gap model and full traceback via three DP matrices (H, E, F)
- **`smith_waterman::align`** — scalar local alignment with zero-floor, max-cell detection, and traceback to the alignment boundary

### Integration
- Added `omics-alignment` to workspace `members` in root `Cargo.toml`
- Added `alignment` feature flag to umbrella `omics` crate with `pub use omics_alignment as alignment`

## Design decisions

- **Scalar-first**: These are correct reference implementations for validating future SIMD-accelerated versions. The algorithms use full O(mn) DP matrices with explicit traceback — straightforward to verify and test against.
- **Generic over `ScoringMatrix`**: The `align` functions are generic over the scoring matrix, allowing the same algorithm to serve both nucleotide (4×4) and protein (20×20) alignment.
- **Separate encoding layer**: `EncodedSequence` decouples the biologically-typed `Molecule` types (with rich Display/FromStr/trait semantics) from the integer-indexed representation that scoring matrices and SIMD kernels require.
- **CIGAR with =/X distinction**: Uses sequence match (=) and mismatch (X) rather than generic match (M), providing precise alignment information needed for variant calling.

## Checklist

- [x] Code builds clean without any errors or warnings
- [x] Tests added (27 unit tests + 8 doc-tests)
- [x] `cargo test -p omics-alignment --all-features` passes
- [x] `cargo clippy -p omics-alignment --all-features -- --deny warnings` passes
- [x] `cargo +nightly fmt --check` passes
- [x] Commit message follows conventional commit style
- [x] PR title follows conventional commit style
- [x] CHANGELOG.md added for the new crate

