### PR TITLE
feat: adds a structural-variant tier to `omics-variation`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ authors = ["The Omics project developers"]
 description = "Foundations for the Rust omics ecosystem"
 homepage = "https://github.com/stjude-rust-labs/omics"
 repository = "https://github.com/stjude-rust-labs/omics"
-rust-version = "1.80.0"
+rust-version = "1.81.0"
 
 [workspace.dependencies]
 anyhow = "1.0.89"

--- a/omics-coordinate/CHANGELOG.md
+++ b/omics-coordinate/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added a `TryFrom<&str>` conversion for `Coordinate`, mirroring the existing
   `FromStr` so coordinates compose with `TryInto`-based constructors
   ([#15](https://github.com/stjude-rust-labs/omics/pull/15)).
+* Derived `Hash` for `Position`, `Base`, and `Interbase`
+  ([#16](https://github.com/stjude-rust-labs/omics/pull/16)).
 
 ## 0.4.0 - 03-19-2026
 

--- a/omics-coordinate/src/position.rs
+++ b/omics-coordinate/src/position.rs
@@ -134,7 +134,7 @@ pub mod r#trait {
 ///
 /// For a more in-depth discussion on what positions are and the notations used
 /// within this crate, please see [this section of the docs](crate#positions).
-#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Position<S: System> {
     /// The coordinate system.
     system: S,

--- a/omics-coordinate/src/system/base.rs
+++ b/omics-coordinate/src/system/base.rs
@@ -21,7 +21,7 @@ const _: () = {
 ///
 /// This coordinate system is also known as the "1-based, fully-closed"
 /// coordinate system.
-#[derive(Copy, Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Base;
 
 impl Base {

--- a/omics-coordinate/src/system/interbase.rs
+++ b/omics-coordinate/src/system/interbase.rs
@@ -21,7 +21,7 @@ const _: () = {
 ///
 /// This coordinate system is also known as the "0-based, half-open" coordinate
 /// system.
-#[derive(Copy, Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Interbase;
 
 impl Interbase {

--- a/omics-molecule/CHANGELOG.md
+++ b/omics-molecule/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Raised the minimum supported Rust version to `1.81`
   ([#16](https://github.com/stjude-rust-labs/omics/pull/16)).
+* **Breaking:** added `Hash` to the `Nucleotide` supertrait bounds, and derived
+  `Hash` for the DNA and RNA nucleotides and for `Sequence`
+  ([#16](https://github.com/stjude-rust-labs/omics/pull/16)).
 
 ## 0.2.0 - 03-19-2026
 

--- a/omics-molecule/CHANGELOG.md
+++ b/omics-molecule/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   concrete `dna::Molecule` / `rna::Molecule`, with `FromStr` and `TryFrom<&str>`
   parsing (a lone `.` denotes the empty allele)
   ([#15](https://github.com/stjude-rust-labs/omics/pull/15)).
+* Added a `Complement` trait giving the Watson-Crick complement of the DNA and
+  RNA nucleotides, and a `Sequence::reverse_complement` method built on it
+  ([#16](https://github.com/stjude-rust-labs/omics/pull/16)).
+
+### Changed
+
+* Raised the minimum supported Rust version to `1.81`
+  ([#16](https://github.com/stjude-rust-labs/omics/pull/16)).
 
 ## 0.2.0 - 03-19-2026
 

--- a/omics-molecule/src/compound.rs
+++ b/omics-molecule/src/compound.rs
@@ -4,4 +4,5 @@ mod kind;
 pub mod nucleotide;
 
 pub use kind::Kind;
+pub use nucleotide::Complement;
 pub use nucleotide::Nucleotide;

--- a/omics-molecule/src/compound/nucleotide.rs
+++ b/omics-molecule/src/compound/nucleotide.rs
@@ -48,3 +48,12 @@ where
     /// a different molecular context (generally from RNA to DNA).
     fn reverse_transcribe(&self) -> T;
 }
+
+/// A trait that provides the Watson-Crick complement of a [`Nucleotide`].
+pub trait Complement
+where
+    Self: Nucleotide,
+{
+    /// Gets the complement of this [`Nucleotide`].
+    fn complement(&self) -> Self;
+}

--- a/omics-molecule/src/compound/nucleotide.rs
+++ b/omics-molecule/src/compound/nucleotide.rs
@@ -55,5 +55,14 @@ where
     Self: Nucleotide,
 {
     /// Gets the complement of this [`Nucleotide`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use omics_molecule::compound::Complement;
+    /// use omics_molecule::polymer::dna::Nucleotide;
+    ///
+    /// assert_eq!(Nucleotide::A.complement(), Nucleotide::T);
+    /// ```
     fn complement(&self) -> Self;
 }

--- a/omics-molecule/src/compound/nucleotide.rs
+++ b/omics-molecule/src/compound/nucleotide.rs
@@ -8,7 +8,7 @@ use crate::compound::Kind;
 
 /// A marker trait that denotes a type of nucleotide.
 pub trait Nucleotide:
-    std::fmt::Debug + std::fmt::Display + Copy + Eq + PartialEq + std::str::FromStr
+    std::fmt::Debug + std::fmt::Display + Copy + Eq + PartialEq + std::hash::Hash + std::str::FromStr
 {
     /// Gets the [`Kind`] type for a given [`Nucleotide`].
     fn kind(&self) -> Kind;

--- a/omics-molecule/src/polymer/dna/nucleotide.rs
+++ b/omics-molecule/src/polymer/dna/nucleotide.rs
@@ -137,6 +137,17 @@ impl std::str::FromStr for Nucleotide {
     }
 }
 
+impl crate::compound::Complement for Nucleotide {
+    fn complement(&self) -> Self {
+        match self {
+            Nucleotide::A => Nucleotide::T,
+            Nucleotide::C => Nucleotide::G,
+            Nucleotide::G => Nucleotide::C,
+            Nucleotide::T => Nucleotide::A,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -163,6 +174,15 @@ mod tests {
         assert_eq!(Nucleotide::C.to_string(), "C");
         assert_eq!(Nucleotide::G.to_string(), "G");
         assert_eq!(Nucleotide::T.to_string(), "T");
+    }
+
+    #[test]
+    fn it_complements_each_dna_base() {
+        use crate::compound::Complement;
+        assert_eq!(Nucleotide::A.complement(), Nucleotide::T);
+        assert_eq!(Nucleotide::T.complement(), Nucleotide::A);
+        assert_eq!(Nucleotide::C.complement(), Nucleotide::G);
+        assert_eq!(Nucleotide::G.complement(), Nucleotide::C);
     }
 
     #[test]

--- a/omics-molecule/src/polymer/dna/nucleotide.rs
+++ b/omics-molecule/src/polymer/dna/nucleotide.rs
@@ -43,7 +43,7 @@ pub enum Error {
 }
 
 /// A nucleotide in an DNA context.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Nucleotide {
     /// Adenine.
     A,

--- a/omics-molecule/src/polymer/rna/nucleotide.rs
+++ b/omics-molecule/src/polymer/rna/nucleotide.rs
@@ -43,7 +43,7 @@ pub enum Error {
 }
 
 /// A nucleotide in an RNA context.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Nucleotide {
     /// Adenine.
     A,

--- a/omics-molecule/src/polymer/rna/nucleotide.rs
+++ b/omics-molecule/src/polymer/rna/nucleotide.rs
@@ -137,6 +137,17 @@ impl std::str::FromStr for Nucleotide {
     }
 }
 
+impl crate::compound::Complement for Nucleotide {
+    fn complement(&self) -> Self {
+        match self {
+            Nucleotide::A => Nucleotide::U,
+            Nucleotide::C => Nucleotide::G,
+            Nucleotide::G => Nucleotide::C,
+            Nucleotide::U => Nucleotide::A,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -163,6 +174,15 @@ mod tests {
         assert_eq!(Nucleotide::C.to_string(), "C");
         assert_eq!(Nucleotide::G.to_string(), "G");
         assert_eq!(Nucleotide::U.to_string(), "U");
+    }
+
+    #[test]
+    fn it_complements_each_rna_base() {
+        use crate::compound::Complement;
+        assert_eq!(Nucleotide::A.complement(), Nucleotide::U);
+        assert_eq!(Nucleotide::U.complement(), Nucleotide::A);
+        assert_eq!(Nucleotide::C.complement(), Nucleotide::G);
+        assert_eq!(Nucleotide::G.complement(), Nucleotide::C);
     }
 
     #[test]

--- a/omics-molecule/src/sequence.rs
+++ b/omics-molecule/src/sequence.rs
@@ -156,6 +156,24 @@ impl<N: Nucleotide> Sequence<N> {
     }
 }
 
+impl<N: Nucleotide + crate::compound::Complement> Sequence<N> {
+    /// Gets the reverse complement of this [`Sequence`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use omics_molecule::polymer::dna::Nucleotide;
+    /// use omics_molecule::sequence::Sequence;
+    ///
+    /// let sequence = "ATGC".parse::<Sequence<Nucleotide>>()?;
+    /// assert_eq!(sequence.reverse_complement().to_string(), "GCAT");
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn reverse_complement(&self) -> Sequence<N> {
+        Sequence::new(self.0.iter().rev().map(|base| base.complement()).collect())
+    }
+}
+
 impl<N: Nucleotide> FromStr for Sequence<N> {
     type Err = ParseError;
 
@@ -242,6 +260,20 @@ mod tests {
         assert_eq!(a.shared_prefix_len(&b), 2); // "AA"
         assert_eq!(a.shared_suffix_len(&b), 1); // "G"
         Ok(())
+    }
+
+    #[test]
+    fn it_reverse_complements_a_dna_sequence() {
+        use crate::polymer::dna::Nucleotide;
+        let seq = Sequence::<Nucleotide>::from_str("ATGC").unwrap();
+        assert_eq!(seq.reverse_complement().to_string(), "GCAT");
+    }
+
+    #[test]
+    fn it_reverse_complements_an_empty_sequence() {
+        use crate::polymer::dna::Nucleotide;
+        let seq = Sequence::<Nucleotide>::from_str(".").unwrap();
+        assert!(seq.reverse_complement().is_empty());
     }
 
     #[test]

--- a/omics-molecule/src/sequence.rs
+++ b/omics-molecule/src/sequence.rs
@@ -28,7 +28,7 @@ pub enum ParseError {
 /// An ordered run of [`Nucleotide`]s representing a variant allele.
 ///
 /// An empty [`Sequence`] is valid and denotes a missing allele.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Sequence<N: Nucleotide>(Vec<N>);
 
 impl<N: Nucleotide> Sequence<N> {

--- a/omics-variation/CHANGELOG.md
+++ b/omics-variation/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Moved the small-variant tier into a `small` module. The previous paths remain
   available through re-exports, including `omics_variation::variant`
   ([#16](https://github.com/stjude-rust-labs/omics/pull/16)).
+* Gave the structural `Kind::Translocation` a `Join` payload alongside its
+  `Locality`, so a co-linear fusion is distinguished from a fold-back
+  (inverted) one, including across contigs
+  ([#16](https://github.com/stjude-rust-labs/omics/pull/16)).
 * Raised the minimum supported Rust version to `1.81`
   ([#16](https://github.com/stjude-rust-labs/omics/pull/16)).
 * **Breaking:** renamed the `Variant::SingleNucleotideVariation` enum variant to

--- a/omics-variation/CHANGELOG.md
+++ b/omics-variation/CHANGELOG.md
@@ -24,9 +24,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added Criterion benchmarks for qualified variant parsing, rejected
   coordinate-system qualifiers, display, normalization, and interval queries
   ([#15](https://github.com/stjude-rust-labs/omics/pull/15)).
+* Added a structural-variant tier under the `structural` module, modeling
+  oriented `Breakend`s, single novel `Adjacency` junctions carrying an optional
+  non-templated insertion, and a `StructuralVariant` event whose `Kind`
+  (deletion, insertion, tandem duplication, inversion, translocation, breakend,
+  or complex) is derived from breakend geometry rather than stored. The tier
+  parses and serializes a compact crate-local string format and ships Criterion
+  benchmarks ([#16](https://github.com/stjude-rust-labs/omics/pull/16)).
 
 ### Changed
 
+* Moved the small-variant tier into a `small` module. The previous paths remain
+  available through re-exports, including `omics_variation::variant`
+  ([#16](https://github.com/stjude-rust-labs/omics/pull/16)).
+* Raised the minimum supported Rust version to `1.81`
+  ([#16](https://github.com/stjude-rust-labs/omics/pull/16)).
 * **Breaking:** renamed the `Variant::SingleNucleotideVariation` enum variant to
   `Variant::Snv` for consistency with the new kind variants (`Mnv`,
   `Insertion`, `Deletion`, `Delins`)

--- a/omics-variation/Cargo.toml
+++ b/omics-variation/Cargo.toml
@@ -28,3 +28,7 @@ workspace = true
 [[bench]]
 name = "variants"
 harness = false
+
+[[bench]]
+name = "structural"
+harness = false

--- a/omics-variation/benches/structural.rs
+++ b/omics-variation/benches/structural.rs
@@ -9,6 +9,7 @@ use std::hint::black_box;
 use criterion::Criterion;
 use criterion::criterion_group;
 use criterion::criterion_main;
+use omics_coordinate::position::Number;
 use omics_molecule::polymer::dna;
 use omics_variation::StructuralVariant;
 use omics_variation::structural::adjacency::Adjacency;
@@ -19,7 +20,7 @@ use omics_variation::structural::orientation::Orientation;
 type Sv = StructuralVariant<dna::Nucleotide>;
 
 /// Builds a breakend on the named contig.
-fn bnd(contig: &str, orientation: Orientation, position: u32) -> Breakend {
+fn bnd(contig: &str, orientation: Orientation, position: Number) -> Breakend {
     Breakend::try_new(contig, orientation, position).unwrap()
 }
 

--- a/omics-variation/benches/structural.rs
+++ b/omics-variation/benches/structural.rs
@@ -1,0 +1,152 @@
+//! Benchmarks for structural variants.
+#![expect(
+    missing_docs,
+    reason = "criterion_group generates undocumented registration functions"
+)]
+
+use std::hint::black_box;
+
+use criterion::Criterion;
+use criterion::criterion_group;
+use criterion::criterion_main;
+use omics_molecule::polymer::dna;
+use omics_variation::StructuralVariant;
+use omics_variation::structural::adjacency::Adjacency;
+use omics_variation::structural::breakend::Breakend;
+use omics_variation::structural::orientation::Orientation;
+
+/// A DNA structural variant used by these benchmarks.
+type Sv = StructuralVariant<dna::Nucleotide>;
+
+/// Builds a breakend on the named contig.
+fn bnd(contig: &str, orientation: Orientation, position: u32) -> Breakend {
+    Breakend::try_new(contig, orientation, position).unwrap()
+}
+
+/// Builds a paired adjacency from two breakends and an insertion token.
+fn paired(x: Breakend, y: Breakend, insertion: &str) -> Adjacency<dna::Nucleotide> {
+    Adjacency::try_new_paired(x, y, insertion.parse().unwrap()).unwrap()
+}
+
+/// Builds a large-deletion fixture.
+fn deletion() -> Sv {
+    Sv::try_new(vec![paired(
+        bnd("seq0", Orientation::LowerFlank, 100),
+        bnd("seq0", Orientation::HigherFlank, 5000),
+        ".",
+    )])
+    .unwrap()
+}
+
+/// Builds a large-insertion fixture.
+fn insertion() -> Sv {
+    Sv::try_new(vec![paired(
+        bnd("seq0", Orientation::LowerFlank, 100),
+        bnd("seq0", Orientation::HigherFlank, 100),
+        "ACGTACGTACGT",
+    )])
+    .unwrap()
+}
+
+/// Builds an interchromosomal-translocation fixture.
+fn interchromosomal_translocation() -> Sv {
+    Sv::try_new(vec![paired(
+        bnd("seq0", Orientation::LowerFlank, 100),
+        bnd("seq1", Orientation::HigherFlank, 900),
+        ".",
+    )])
+    .unwrap()
+}
+
+/// Builds an intrachromosomal-translocation fixture.
+fn intrachromosomal_translocation() -> Sv {
+    let origin = paired(
+        bnd("seq0", Orientation::LowerFlank, 100),
+        bnd("seq0", Orientation::HigherFlank, 200),
+        ".",
+    );
+    let target_left = paired(
+        bnd("seq0", Orientation::LowerFlank, 400),
+        bnd("seq0", Orientation::HigherFlank, 100),
+        ".",
+    );
+    let target_right = paired(
+        bnd("seq0", Orientation::LowerFlank, 200),
+        bnd("seq0", Orientation::HigherFlank, 400),
+        ".",
+    );
+    Sv::try_new(vec![origin, target_left, target_right]).unwrap()
+}
+
+/// Builds an inversion fixture.
+fn inversion() -> Sv {
+    let lower = paired(
+        bnd("seq0", Orientation::LowerFlank, 100),
+        bnd("seq0", Orientation::LowerFlank, 300),
+        ".",
+    );
+    let higher = paired(
+        bnd("seq0", Orientation::HigherFlank, 100),
+        bnd("seq0", Orientation::HigherFlank, 300),
+        ".",
+    );
+    Sv::try_new(vec![lower, higher]).unwrap()
+}
+
+/// Builds an internal-tandem-duplication fixture.
+fn tandem_duplication() -> Sv {
+    Sv::try_new(vec![paired(
+        bnd("seq0", Orientation::HigherFlank, 100),
+        bnd("seq0", Orientation::LowerFlank, 160),
+        "GAT",
+    )])
+    .unwrap()
+}
+
+/// The six required events, paired with a stable benchmark label.
+fn fixtures() -> Vec<(&'static str, Sv)> {
+    vec![
+        ("deletion", deletion()),
+        ("insertion", insertion()),
+        (
+            "interchromosomal_translocation",
+            interchromosomal_translocation(),
+        ),
+        (
+            "intrachromosomal_translocation",
+            intrachromosomal_translocation(),
+        ),
+        ("inversion", inversion()),
+        ("tandem_duplication", tandem_duplication()),
+    ]
+}
+
+/// Parses a serialized fixture back into a structural variant.
+fn parse(input: &str) -> Sv {
+    match input.parse() {
+        Ok(variant) => variant,
+        Err(err) => panic!("benchmark fixture failed to parse; {err}"),
+    }
+}
+
+/// Registers structural-variant parsing benchmarks over all six events.
+fn parse_benches(c: &mut Criterion) {
+    for (label, variant) in fixtures() {
+        let rendered = variant.to_string();
+        c.bench_function(&format!("structural::parse::{label}"), |b| {
+            b.iter(|| parse(black_box(&rendered)))
+        });
+    }
+}
+
+/// Registers structural-variant classification benchmarks over all six events.
+fn classify_benches(c: &mut Criterion) {
+    for (label, variant) in fixtures() {
+        c.bench_function(&format!("structural::classify::{label}"), |b| {
+            b.iter(|| black_box(&variant).kind())
+        });
+    }
+}
+
+criterion_group!(benches, parse_benches, classify_benches);
+criterion_main!(benches);

--- a/omics-variation/src/lib.rs
+++ b/omics-variation/src/lib.rs
@@ -1,15 +1,21 @@
-//! Small sequence variants.
+//! Sequence and structural variants.
 //!
 //! `omics-variation` represents genomic changes that can be written as a
 //! reference allele and an alternate allele at one locus. This covers single
 //! nucleotide variants (`SNV`s), multi-nucleotide variants (`MNV`s),
 //! insertions, deletions, and deletion-insertions (`delins`). Larger events
-//! such as copy-number variants, inversions, translocations, and breakends
-//! need additional structure and are not modeled by this crate.
+//! such as inversions, translocations, and breakends need additional structure
+//! and are now modeled by the [`structural`] module.
 //!
 //! The central type is [`Variant`]. A [`Variant`] is generic over the
 //! nucleotide type, so the same representation works for DNA and RNA alleles
 //! from `omics-molecule`.
+//!
+//! Beyond small variants, the [`structural`] module models breakends, novel
+//! adjacencies, and structural-variant events such as large deletions, large
+//! insertions, inversions, tandem duplications, and translocations. A
+//! structural variant derives its [`structural::Kind`] from breakend geometry
+//! rather than storing it.
 //!
 //! ```
 //! use omics_molecule::polymer::dna;
@@ -19,6 +25,22 @@
 //! let variant = "seq0:+:100(b):A:C".parse::<Variant<dna::Nucleotide>>()?;
 //! assert_eq!(variant.kind(), Kind::Snv);
 //! assert_eq!(variant.to_string(), "seq0:+:100(b):A:C");
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! ```
+//! use omics_molecule::polymer::dna;
+//! use omics_variation::StructuralKind;
+//! use omics_variation::StructuralVariant;
+//! use omics_variation::structural::adjacency::Adjacency;
+//! use omics_variation::structural::breakend::Breakend;
+//! use omics_variation::structural::orientation::Orientation;
+//!
+//! let a = Breakend::try_new("seq0", Orientation::LowerFlank, 100)?;
+//! let b = Breakend::try_new("seq0", Orientation::HigherFlank, 200)?;
+//! let adjacency = Adjacency::<dna::Nucleotide>::try_new_paired(a, b, ".".parse()?)?;
+//! let variant = StructuralVariant::try_new(vec![adjacency])?;
+//! assert_eq!(variant.kind(), StructuralKind::Deletion);
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 //!
@@ -156,6 +178,8 @@ use thiserror::Error;
 pub mod small;
 pub mod structural;
 
+/// The small-variant module, retained at its historical path.
+pub use small as variant;
 use small::Alteration;
 use small::Kind;
 pub use small::deletion;
@@ -163,9 +187,9 @@ pub use small::delins;
 pub use small::insertion;
 pub use small::mnv;
 pub use small::snv;
-
-/// The small-variant module, retained at its historical path.
-pub use small as variant;
+pub use structural::Kind as StructuralKind;
+pub use structural::Locality;
+pub use structural::StructuralVariant;
 
 /// An error related to a top-level [`Variant`].
 #[derive(Error, Debug)]

--- a/omics-variation/src/lib.rs
+++ b/omics-variation/src/lib.rs
@@ -154,6 +154,7 @@ use omics_molecule::sequence::Sequence;
 use thiserror::Error;
 
 pub mod small;
+pub mod structural;
 
 use small::Alteration;
 use small::Kind;

--- a/omics-variation/src/lib.rs
+++ b/omics-variation/src/lib.rs
@@ -187,6 +187,7 @@ pub use small::delins;
 pub use small::insertion;
 pub use small::mnv;
 pub use small::snv;
+pub use structural::Join;
 pub use structural::Kind as StructuralKind;
 pub use structural::Locality;
 pub use structural::StructuralVariant;

--- a/omics-variation/src/lib.rs
+++ b/omics-variation/src/lib.rs
@@ -153,15 +153,18 @@ use omics_molecule::compound::Nucleotide;
 use omics_molecule::sequence::Sequence;
 use thiserror::Error;
 
-pub mod variant;
+pub mod small;
 
-use variant::Alteration;
-use variant::Kind;
-pub use variant::deletion;
-pub use variant::delins;
-pub use variant::insertion;
-pub use variant::mnv;
-pub use variant::snv;
+use small::Alteration;
+use small::Kind;
+pub use small::deletion;
+pub use small::delins;
+pub use small::insertion;
+pub use small::mnv;
+pub use small::snv;
+
+/// The small-variant module, retained at its historical path.
+pub use small as variant;
 
 /// An error related to a top-level [`Variant`].
 #[derive(Error, Debug)]

--- a/omics-variation/src/small.rs
+++ b/omics-variation/src/small.rs
@@ -1,4 +1,4 @@
-//! Small variants and their shared representation.
+//! The small-variant tier.
 //!
 //! Every small variant is a reference allele and an alternate allele anchored
 //! at a coordinate. [`Alteration`] is the shared core carrying the two alleles

--- a/omics-variation/src/small/deletion.rs
+++ b/omics-variation/src/small/deletion.rs
@@ -1,73 +1,73 @@
-//! Combined deletion-insertions.
+//! Deletions.
 
 use omics_coordinate::Coordinate;
 use omics_coordinate::Interval;
 use omics_coordinate::coordinate;
 use omics_coordinate::position::Number;
 use omics_coordinate::system::Base;
+use omics_coordinate::system::Interbase;
 use omics_molecule::compound::Nucleotide;
 use omics_molecule::sequence;
 use omics_molecule::sequence::Sequence;
 
-use crate::variant::Alteration;
-use crate::variant::Kind;
-use crate::variant::KindError;
-use crate::variant::base_interval;
+use crate::small::Alteration;
+use crate::small::Kind;
+use crate::small::KindError;
+use crate::small::base_interval;
+use crate::small::interbase_interval_before_base;
 
-/// A combined deletion-insertion of differing lengths.
+/// A deletion of one or more reference bases.
 ///
 /// Serialized top-level variants use base coordinates with the `(b)`
-/// qualifier. Interbase coordinates with `(i)` are rejected because a delins
-/// replaces existing bases over a base interval.
+/// qualifier. Interbase coordinates with `(i)` are rejected because a deletion
+/// removes existing bases over a base interval.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Variant<N: Nucleotide> {
-    /// The coordinate of the first replaced base.
+    /// The coordinate of the first deleted base.
     ///
     /// Construction guarantees that advancing this forward by
     /// `reference.len() - 1` stays within the position bounds, so
     /// [`interval`](Self::interval) cannot overflow.
     coordinate: Coordinate<Base>,
 
-    /// Both alleles non-empty and of differing lengths.
+    /// A non-empty reference allele paired with an empty alternate allele.
     ///
-    /// Construction guarantees `kind()` is [`Kind::Delins`].
+    /// Construction guarantees `kind()` is [`Kind::Deletion`].
     alteration: Alteration<N>,
 }
 
 impl<N: Nucleotide> Variant<N> {
-    /// Attempts to create a new delins from a coordinate and the reference and
-    /// alternate bases.
+    /// Attempts to create a new deletion from a coordinate and the deleted
+    /// reference bases.
     ///
     /// # Examples
     ///
     /// ```
     /// use omics_molecule::polymer::dna::Nucleotide;
-    /// use omics_variation::variant::delins::Variant;
+    /// use omics_variation::variant::deletion::Variant;
     ///
-    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT", "G")?;
+    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT")?;
     /// assert_eq!(variant.reference().to_string(), "AT");
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn try_new(
         coordinate: impl TryInto<Coordinate<Base>, Error = coordinate::Error>,
         reference: impl TryInto<Sequence<N>, Error = sequence::ParseError>,
-        alternate: impl TryInto<Sequence<N>, Error = sequence::ParseError>,
     ) -> Result<Self, KindError> {
         let coordinate = coordinate.try_into()?;
         let reference = reference.try_into()?;
-        let alternate = alternate.try_into()?;
-        let alteration = Alteration::try_new(reference, alternate)?;
+        let alteration = Alteration::try_new(reference, Sequence::new(Vec::new()))?;
         Self::try_from((coordinate, alteration))
     }
 
-    /// Gets the coordinate of the first replaced base.
+    /// Gets the coordinate of the first deleted base.
     ///
     /// # Examples
     ///
     /// ```
     /// # use omics_molecule::polymer::dna::Nucleotide;
-    /// # use omics_variation::variant::delins::Variant;
-    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT", "G")?;
+    /// # use omics_variation::variant::deletion::Variant;
+    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT")?;
     /// assert_eq!(variant.coordinate().position().get(), 100);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -75,14 +75,14 @@ impl<N: Nucleotide> Variant<N> {
         &self.coordinate
     }
 
-    /// Gets the reference allele.
+    /// Gets the deleted reference allele.
     ///
     /// # Examples
     ///
     /// ```
     /// # use omics_molecule::polymer::dna::Nucleotide;
-    /// # use omics_variation::variant::delins::Variant;
-    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT", "G")?;
+    /// # use omics_variation::variant::deletion::Variant;
+    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT")?;
     /// assert_eq!(variant.reference().to_string(), "AT");
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -90,32 +90,17 @@ impl<N: Nucleotide> Variant<N> {
         self.alteration.reference()
     }
 
-    /// Gets the alternate allele.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use omics_molecule::polymer::dna::Nucleotide;
-    /// # use omics_variation::variant::delins::Variant;
-    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT", "G")?;
-    /// assert_eq!(variant.alternate().to_string(), "G");
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    pub fn alternate(&self) -> &Sequence<N> {
-        self.alteration.alternate()
-    }
-
     /// Gets the interval spanned by the reference allele.
     ///
     /// Use this for reference-facing overlap and annotation queries. This is
-    /// the interval replaced on the reference.
+    /// the interval deleted from the reference.
     ///
     /// # Examples
     ///
     /// ```
     /// # use omics_molecule::polymer::dna::Nucleotide;
-    /// # use omics_variation::variant::delins::Variant;
-    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT", "G")?;
+    /// # use omics_variation::variant::deletion::Variant;
+    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT")?;
     /// assert_eq!(variant.interval().end().position().get(), 101);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -124,32 +109,26 @@ impl<N: Nucleotide> Variant<N> {
         base_interval(&self.coordinate, self.alteration.reference().len()).unwrap()
     }
 
-    /// Gets the local interval spanned by the alternate allele.
+    /// Gets the zero-width interval spanned by the alternate allele.
     ///
-    /// The alternate interval starts at the same coordinate as the reference
-    /// interval and spans the alternate allele length. This describes the
-    /// local replacement sequence, not a globally projected query coordinate.
+    /// A deletion has an empty alternate allele. Its alternate interval is the
+    /// interbase boundary immediately before the deleted reference interval.
     /// Use this for local alternate-allele span queries.
     ///
     /// # Examples
     ///
     /// ```
     /// # use omics_molecule::polymer::dna::Nucleotide;
-    /// # use omics_variation::variant::delins::Variant;
-    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT", "G")?;
+    /// # use omics_variation::variant::deletion::Variant;
+    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT")?;
     /// assert_eq!(
-    ///     variant
-    ///         .alternate_interval()
-    ///         .unwrap()
-    ///         .start()
-    ///         .position()
-    ///         .get(),
-    ///     100
+    ///     variant.alternate_interval().start().position().get(),
+    ///     variant.alternate_interval().end().position().get()
     /// );
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn alternate_interval(&self) -> Option<Interval<Base>> {
-        base_interval(&self.coordinate, self.alteration.alternate().len())
+    pub fn alternate_interval(&self) -> Interval<Interbase> {
+        interbase_interval_before_base(&self.coordinate)
     }
 
     /// Gets the interval spanned by the reference allele.
@@ -163,9 +142,9 @@ impl<N: Nucleotide> Variant<N> {
     ///
     /// ```
     /// # use omics_molecule::polymer::dna::Nucleotide;
-    /// # use omics_variation::variant::delins::Variant;
-    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT", "G")?;
-    /// assert_eq!(variant.alteration().alternate().to_string(), "G");
+    /// # use omics_variation::variant::deletion::Variant;
+    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT")?;
+    /// assert_eq!(variant.alteration().reference().to_string(), "AT");
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn alteration(&self) -> &Alteration<N> {
@@ -176,7 +155,7 @@ impl<N: Nucleotide> Variant<N> {
 impl<N: Nucleotide> TryFrom<(Coordinate<Base>, Alteration<N>)> for Variant<N> {
     type Error = KindError;
 
-    /// Builds a delins from a base [`Coordinate`] and a classified delins
+    /// Builds a deletion from a base [`Coordinate`] and a classified deletion
     /// [`Alteration`].
     ///
     /// # Examples
@@ -186,10 +165,10 @@ impl<N: Nucleotide> TryFrom<(Coordinate<Base>, Alteration<N>)> for Variant<N> {
     /// use omics_coordinate::system::Base;
     /// use omics_molecule::polymer::dna::Nucleotide;
     /// use omics_variation::variant::Alteration;
-    /// use omics_variation::variant::delins::Variant;
+    /// use omics_variation::variant::deletion::Variant;
     ///
     /// let coordinate = Coordinate::<Base>::try_from("seq0:+:100")?;
-    /// let alteration = Alteration::<Nucleotide>::try_new("AT".parse()?, "G".parse()?)?;
+    /// let alteration = Alteration::<Nucleotide>::try_new("AT".parse()?, ".".parse()?)?;
     /// let variant = Variant::try_from((coordinate, alteration))?;
     /// assert_eq!(variant.reference().to_string(), "AT");
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -198,9 +177,9 @@ impl<N: Nucleotide> TryFrom<(Coordinate<Base>, Alteration<N>)> for Variant<N> {
         (coordinate, alteration): (Coordinate<Base>, Alteration<N>),
     ) -> Result<Self, Self::Error> {
         let found = alteration.kind();
-        if found != Kind::Delins {
+        if found != Kind::Deletion {
             return Err(KindError::WrongKind {
-                expected: Kind::Delins,
+                expected: Kind::Deletion,
                 found,
             });
         }
@@ -227,19 +206,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn it_builds_a_delins_from_raw_parts() {
-        let variant = Variant::<dna::Nucleotide>::try_new("seq0:+:100", "AT", "G").unwrap();
+    fn it_builds_a_deletion_from_raw_parts() {
+        let variant = Variant::<dna::Nucleotide>::try_new("seq0:+:100", "AT").unwrap();
         assert_eq!(variant.reference().to_string(), "AT");
-        assert_eq!(variant.alternate().to_string(), "G");
+        assert_eq!(variant.interval().start().position().get(), 100);
         assert_eq!(variant.interval().end().position().get(), 101);
     }
 
     #[test]
-    fn it_builds_a_delins_from_an_alteration() {
+    fn it_builds_a_deletion_from_an_alteration() {
         let coordinate = Coordinate::<Base>::try_from("seq0:+:100").unwrap();
         let alteration = Alteration::<dna::Nucleotide>::try_new(
             Sequence::try_from("AT").unwrap(),
-            Sequence::try_from("G").unwrap(),
+            Sequence::try_from(".").unwrap(),
         )
         .unwrap();
         let variant = Variant::try_from((coordinate, alteration)).unwrap();
@@ -247,29 +226,38 @@ mod tests {
     }
 
     #[test]
-    fn it_rejects_non_delins() {
+    fn it_rejects_a_non_deletion_alteration() {
         let coordinate = Coordinate::<Base>::try_from("seq0:+:100").unwrap();
-        // An MNV, not a delins.
+        // An SNV, not a deletion.
         let alteration = Alteration::<dna::Nucleotide>::try_new(
-            Sequence::try_from("AT").unwrap(),
-            Sequence::try_from("GC").unwrap(),
+            Sequence::try_from("A").unwrap(),
+            Sequence::try_from("C").unwrap(),
         )
         .unwrap();
         let err = Variant::try_from((coordinate, alteration)).unwrap_err();
         assert!(matches!(
             err,
             KindError::WrongKind {
-                expected: Kind::Delins,
-                found: Kind::Mnv
+                expected: Kind::Deletion,
+                found: Kind::Snv
             }
         ));
     }
 
     #[test]
+    fn it_rejects_an_empty_reference() {
+        let err = Variant::<dna::Nucleotide>::try_new("seq0:+:100", ".").unwrap_err();
+        assert!(matches!(
+            err,
+            KindError::Alteration(crate::small::Error::BothEmpty)
+        ));
+    }
+
+    #[test]
     fn it_rejects_a_span_that_overflows() {
-        // Two-base reference delins at MAX would need MAX+1.
+        // Two-base deletion at MAX would need MAX+1.
         let coordinate = format!("seq0:+:{}", Number::MAX);
-        let err = Variant::<dna::Nucleotide>::try_new(coordinate.as_str(), "AT", "G").unwrap_err();
+        let err = Variant::<dna::Nucleotide>::try_new(coordinate.as_str(), "AT").unwrap_err();
         assert!(matches!(err, KindError::SpanOverflow));
     }
 }

--- a/omics-variation/src/small/delins.rs
+++ b/omics-variation/src/small/delins.rs
@@ -1,73 +1,73 @@
-//! Deletions.
+//! Combined deletion-insertions.
 
 use omics_coordinate::Coordinate;
 use omics_coordinate::Interval;
 use omics_coordinate::coordinate;
 use omics_coordinate::position::Number;
 use omics_coordinate::system::Base;
-use omics_coordinate::system::Interbase;
 use omics_molecule::compound::Nucleotide;
 use omics_molecule::sequence;
 use omics_molecule::sequence::Sequence;
 
-use crate::variant::Alteration;
-use crate::variant::Kind;
-use crate::variant::KindError;
-use crate::variant::base_interval;
-use crate::variant::interbase_interval_before_base;
+use crate::small::Alteration;
+use crate::small::Kind;
+use crate::small::KindError;
+use crate::small::base_interval;
 
-/// A deletion of one or more reference bases.
+/// A combined deletion-insertion of differing lengths.
 ///
 /// Serialized top-level variants use base coordinates with the `(b)`
-/// qualifier. Interbase coordinates with `(i)` are rejected because a deletion
-/// removes existing bases over a base interval.
+/// qualifier. Interbase coordinates with `(i)` are rejected because a delins
+/// replaces existing bases over a base interval.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Variant<N: Nucleotide> {
-    /// The coordinate of the first deleted base.
+    /// The coordinate of the first replaced base.
     ///
     /// Construction guarantees that advancing this forward by
     /// `reference.len() - 1` stays within the position bounds, so
     /// [`interval`](Self::interval) cannot overflow.
     coordinate: Coordinate<Base>,
 
-    /// A non-empty reference allele paired with an empty alternate allele.
+    /// Both alleles non-empty and of differing lengths.
     ///
-    /// Construction guarantees `kind()` is [`Kind::Deletion`].
+    /// Construction guarantees `kind()` is [`Kind::Delins`].
     alteration: Alteration<N>,
 }
 
 impl<N: Nucleotide> Variant<N> {
-    /// Attempts to create a new deletion from a coordinate and the deleted
-    /// reference bases.
+    /// Attempts to create a new delins from a coordinate and the reference and
+    /// alternate bases.
     ///
     /// # Examples
     ///
     /// ```
     /// use omics_molecule::polymer::dna::Nucleotide;
-    /// use omics_variation::variant::deletion::Variant;
+    /// use omics_variation::variant::delins::Variant;
     ///
-    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT")?;
+    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT", "G")?;
     /// assert_eq!(variant.reference().to_string(), "AT");
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn try_new(
         coordinate: impl TryInto<Coordinate<Base>, Error = coordinate::Error>,
         reference: impl TryInto<Sequence<N>, Error = sequence::ParseError>,
+        alternate: impl TryInto<Sequence<N>, Error = sequence::ParseError>,
     ) -> Result<Self, KindError> {
         let coordinate = coordinate.try_into()?;
         let reference = reference.try_into()?;
-        let alteration = Alteration::try_new(reference, Sequence::new(Vec::new()))?;
+        let alternate = alternate.try_into()?;
+        let alteration = Alteration::try_new(reference, alternate)?;
         Self::try_from((coordinate, alteration))
     }
 
-    /// Gets the coordinate of the first deleted base.
+    /// Gets the coordinate of the first replaced base.
     ///
     /// # Examples
     ///
     /// ```
     /// # use omics_molecule::polymer::dna::Nucleotide;
-    /// # use omics_variation::variant::deletion::Variant;
-    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT")?;
+    /// # use omics_variation::variant::delins::Variant;
+    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT", "G")?;
     /// assert_eq!(variant.coordinate().position().get(), 100);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -75,14 +75,14 @@ impl<N: Nucleotide> Variant<N> {
         &self.coordinate
     }
 
-    /// Gets the deleted reference allele.
+    /// Gets the reference allele.
     ///
     /// # Examples
     ///
     /// ```
     /// # use omics_molecule::polymer::dna::Nucleotide;
-    /// # use omics_variation::variant::deletion::Variant;
-    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT")?;
+    /// # use omics_variation::variant::delins::Variant;
+    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT", "G")?;
     /// assert_eq!(variant.reference().to_string(), "AT");
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -90,17 +90,32 @@ impl<N: Nucleotide> Variant<N> {
         self.alteration.reference()
     }
 
-    /// Gets the interval spanned by the reference allele.
-    ///
-    /// Use this for reference-facing overlap and annotation queries. This is
-    /// the interval deleted from the reference.
+    /// Gets the alternate allele.
     ///
     /// # Examples
     ///
     /// ```
     /// # use omics_molecule::polymer::dna::Nucleotide;
-    /// # use omics_variation::variant::deletion::Variant;
-    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT")?;
+    /// # use omics_variation::variant::delins::Variant;
+    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT", "G")?;
+    /// assert_eq!(variant.alternate().to_string(), "G");
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn alternate(&self) -> &Sequence<N> {
+        self.alteration.alternate()
+    }
+
+    /// Gets the interval spanned by the reference allele.
+    ///
+    /// Use this for reference-facing overlap and annotation queries. This is
+    /// the interval replaced on the reference.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use omics_molecule::polymer::dna::Nucleotide;
+    /// # use omics_variation::variant::delins::Variant;
+    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT", "G")?;
     /// assert_eq!(variant.interval().end().position().get(), 101);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -109,26 +124,32 @@ impl<N: Nucleotide> Variant<N> {
         base_interval(&self.coordinate, self.alteration.reference().len()).unwrap()
     }
 
-    /// Gets the zero-width interval spanned by the alternate allele.
+    /// Gets the local interval spanned by the alternate allele.
     ///
-    /// A deletion has an empty alternate allele. Its alternate interval is the
-    /// interbase boundary immediately before the deleted reference interval.
+    /// The alternate interval starts at the same coordinate as the reference
+    /// interval and spans the alternate allele length. This describes the
+    /// local replacement sequence, not a globally projected query coordinate.
     /// Use this for local alternate-allele span queries.
     ///
     /// # Examples
     ///
     /// ```
     /// # use omics_molecule::polymer::dna::Nucleotide;
-    /// # use omics_variation::variant::deletion::Variant;
-    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT")?;
+    /// # use omics_variation::variant::delins::Variant;
+    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT", "G")?;
     /// assert_eq!(
-    ///     variant.alternate_interval().start().position().get(),
-    ///     variant.alternate_interval().end().position().get()
+    ///     variant
+    ///         .alternate_interval()
+    ///         .unwrap()
+    ///         .start()
+    ///         .position()
+    ///         .get(),
+    ///     100
     /// );
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn alternate_interval(&self) -> Interval<Interbase> {
-        interbase_interval_before_base(&self.coordinate)
+    pub fn alternate_interval(&self) -> Option<Interval<Base>> {
+        base_interval(&self.coordinate, self.alteration.alternate().len())
     }
 
     /// Gets the interval spanned by the reference allele.
@@ -142,9 +163,9 @@ impl<N: Nucleotide> Variant<N> {
     ///
     /// ```
     /// # use omics_molecule::polymer::dna::Nucleotide;
-    /// # use omics_variation::variant::deletion::Variant;
-    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT")?;
-    /// assert_eq!(variant.alteration().reference().to_string(), "AT");
+    /// # use omics_variation::variant::delins::Variant;
+    /// let variant = Variant::<Nucleotide>::try_new("seq0:+:100", "AT", "G")?;
+    /// assert_eq!(variant.alteration().alternate().to_string(), "G");
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn alteration(&self) -> &Alteration<N> {
@@ -155,7 +176,7 @@ impl<N: Nucleotide> Variant<N> {
 impl<N: Nucleotide> TryFrom<(Coordinate<Base>, Alteration<N>)> for Variant<N> {
     type Error = KindError;
 
-    /// Builds a deletion from a base [`Coordinate`] and a classified deletion
+    /// Builds a delins from a base [`Coordinate`] and a classified delins
     /// [`Alteration`].
     ///
     /// # Examples
@@ -165,10 +186,10 @@ impl<N: Nucleotide> TryFrom<(Coordinate<Base>, Alteration<N>)> for Variant<N> {
     /// use omics_coordinate::system::Base;
     /// use omics_molecule::polymer::dna::Nucleotide;
     /// use omics_variation::variant::Alteration;
-    /// use omics_variation::variant::deletion::Variant;
+    /// use omics_variation::variant::delins::Variant;
     ///
     /// let coordinate = Coordinate::<Base>::try_from("seq0:+:100")?;
-    /// let alteration = Alteration::<Nucleotide>::try_new("AT".parse()?, ".".parse()?)?;
+    /// let alteration = Alteration::<Nucleotide>::try_new("AT".parse()?, "G".parse()?)?;
     /// let variant = Variant::try_from((coordinate, alteration))?;
     /// assert_eq!(variant.reference().to_string(), "AT");
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -177,9 +198,9 @@ impl<N: Nucleotide> TryFrom<(Coordinate<Base>, Alteration<N>)> for Variant<N> {
         (coordinate, alteration): (Coordinate<Base>, Alteration<N>),
     ) -> Result<Self, Self::Error> {
         let found = alteration.kind();
-        if found != Kind::Deletion {
+        if found != Kind::Delins {
             return Err(KindError::WrongKind {
-                expected: Kind::Deletion,
+                expected: Kind::Delins,
                 found,
             });
         }
@@ -206,19 +227,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn it_builds_a_deletion_from_raw_parts() {
-        let variant = Variant::<dna::Nucleotide>::try_new("seq0:+:100", "AT").unwrap();
+    fn it_builds_a_delins_from_raw_parts() {
+        let variant = Variant::<dna::Nucleotide>::try_new("seq0:+:100", "AT", "G").unwrap();
         assert_eq!(variant.reference().to_string(), "AT");
-        assert_eq!(variant.interval().start().position().get(), 100);
+        assert_eq!(variant.alternate().to_string(), "G");
         assert_eq!(variant.interval().end().position().get(), 101);
     }
 
     #[test]
-    fn it_builds_a_deletion_from_an_alteration() {
+    fn it_builds_a_delins_from_an_alteration() {
         let coordinate = Coordinate::<Base>::try_from("seq0:+:100").unwrap();
         let alteration = Alteration::<dna::Nucleotide>::try_new(
             Sequence::try_from("AT").unwrap(),
-            Sequence::try_from(".").unwrap(),
+            Sequence::try_from("G").unwrap(),
         )
         .unwrap();
         let variant = Variant::try_from((coordinate, alteration)).unwrap();
@@ -226,38 +247,29 @@ mod tests {
     }
 
     #[test]
-    fn it_rejects_a_non_deletion_alteration() {
+    fn it_rejects_non_delins() {
         let coordinate = Coordinate::<Base>::try_from("seq0:+:100").unwrap();
-        // An SNV, not a deletion.
+        // An MNV, not a delins.
         let alteration = Alteration::<dna::Nucleotide>::try_new(
-            Sequence::try_from("A").unwrap(),
-            Sequence::try_from("C").unwrap(),
+            Sequence::try_from("AT").unwrap(),
+            Sequence::try_from("GC").unwrap(),
         )
         .unwrap();
         let err = Variant::try_from((coordinate, alteration)).unwrap_err();
         assert!(matches!(
             err,
             KindError::WrongKind {
-                expected: Kind::Deletion,
-                found: Kind::Snv
+                expected: Kind::Delins,
+                found: Kind::Mnv
             }
         ));
     }
 
     #[test]
-    fn it_rejects_an_empty_reference() {
-        let err = Variant::<dna::Nucleotide>::try_new("seq0:+:100", ".").unwrap_err();
-        assert!(matches!(
-            err,
-            KindError::Alteration(crate::variant::Error::BothEmpty)
-        ));
-    }
-
-    #[test]
     fn it_rejects_a_span_that_overflows() {
-        // Two-base deletion at MAX would need MAX+1.
+        // Two-base reference delins at MAX would need MAX+1.
         let coordinate = format!("seq0:+:{}", Number::MAX);
-        let err = Variant::<dna::Nucleotide>::try_new(coordinate.as_str(), "AT").unwrap_err();
+        let err = Variant::<dna::Nucleotide>::try_new(coordinate.as_str(), "AT", "G").unwrap_err();
         assert!(matches!(err, KindError::SpanOverflow));
     }
 }

--- a/omics-variation/src/small/insertion.rs
+++ b/omics-variation/src/small/insertion.rs
@@ -9,11 +9,11 @@ use omics_molecule::compound::Nucleotide;
 use omics_molecule::sequence;
 use omics_molecule::sequence::Sequence;
 
-use crate::variant::Alteration;
-use crate::variant::Kind;
-use crate::variant::KindError;
-use crate::variant::base_interval;
-use crate::variant::interbase_interval;
+use crate::small::Alteration;
+use crate::small::Kind;
+use crate::small::KindError;
+use crate::small::base_interval;
+use crate::small::interbase_interval;
 
 /// An insertion of one or more bases at an interbase boundary.
 ///

--- a/omics-variation/src/small/mnv.rs
+++ b/omics-variation/src/small/mnv.rs
@@ -9,10 +9,10 @@ use omics_molecule::compound::Nucleotide;
 use omics_molecule::sequence;
 use omics_molecule::sequence::Sequence;
 
-use crate::variant::Alteration;
-use crate::variant::Kind;
-use crate::variant::KindError;
-use crate::variant::base_interval;
+use crate::small::Alteration;
+use crate::small::Kind;
+use crate::small::KindError;
+use crate::small::base_interval;
 
 /// A multi-nucleotide variant, an equal-length substitution of two or more
 /// bases.

--- a/omics-variation/src/small/snv.rs
+++ b/omics-variation/src/small/snv.rs
@@ -15,10 +15,10 @@ use thiserror::Error;
 use crate::PositionQualifier;
 use crate::qualified_position;
 use crate::split_qualified_position;
-use crate::variant::Alteration;
-use crate::variant::Kind;
-use crate::variant::KindError;
-use crate::variant::base_interval;
+use crate::small::Alteration;
+use crate::small::Kind;
+use crate::small::KindError;
+use crate::small::base_interval;
 
 /// A parse error related to a [`Variant`].
 #[derive(Error, Debug)]
@@ -69,7 +69,7 @@ where
 
     /// The alleles did not form a valid alteration.
     #[error(transparent)]
-    Alteration(crate::variant::Error),
+    Alteration(crate::small::Error),
 }
 
 /// A single nucleotide variant.
@@ -124,7 +124,7 @@ where
             Sequence::new(vec![alternate_nucleotide]),
         )
         .map_err(|err| match err {
-            crate::variant::Error::Identical(_) => Error::Identical(reference_nucleotide),
+            crate::small::Error::Identical(_) => Error::Identical(reference_nucleotide),
             other => Error::Alteration(other),
         })?;
 

--- a/omics-variation/src/small/snv.rs
+++ b/omics-variation/src/small/snv.rs
@@ -14,11 +14,11 @@ use thiserror::Error;
 
 use crate::PositionQualifier;
 use crate::qualified_position;
-use crate::split_qualified_position;
 use crate::small::Alteration;
 use crate::small::Kind;
 use crate::small::KindError;
 use crate::small::base_interval;
+use crate::split_qualified_position;
 
 /// A parse error related to a [`Variant`].
 #[derive(Error, Debug)]

--- a/omics-variation/src/structural.rs
+++ b/omics-variation/src/structural.rs
@@ -254,9 +254,6 @@ pub enum ParseError {
 /// canonical key and deduplicated, so that equality and classification do not
 /// depend on the input order and are insensitive to duplicates.
 ///
-/// `Hash` is intentionally not derived because `Adjacency` does not implement
-/// it.
-///
 /// A structural variant serializes as its adjacency tokens joined with `;`.
 ///
 /// # Examples
@@ -270,7 +267,7 @@ pub enum ParseError {
 /// assert_eq!(variant.to_string(), rendered);
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct StructuralVariant<N: Nucleotide> {
     /// The adjacencies making up the event, held in normalized order.
     adjacencies: Vec<Adjacency<N>>,

--- a/omics-variation/src/structural.rs
+++ b/omics-variation/src/structural.rs
@@ -1,0 +1,3 @@
+//! The structural-variant tier.
+
+pub mod orientation;

--- a/omics-variation/src/structural.rs
+++ b/omics-variation/src/structural.rs
@@ -1,3 +1,4 @@
 //! The structural-variant tier.
 
+pub mod breakend;
 pub mod orientation;

--- a/omics-variation/src/structural.rs
+++ b/omics-variation/src/structural.rs
@@ -148,7 +148,8 @@ impl<N: Nucleotide> StructuralVariant<N> {
     pub fn kind(&self) -> Kind {
         match self.adjacencies.as_slice() {
             [single] => classify_single(single),
-            // Multi-adjacency classification is added in the next task.
+            [first, second] => classify_pair(first, second),
+            [first, second, third] => classify_triple(first, second, third),
             _ => Kind::Complex,
         }
     }
@@ -186,6 +187,49 @@ fn adjacency_key<N: Nucleotide>(adjacency: &Adjacency<N>) -> (u8, BreakendKey, B
     }
 }
 
+/// Gets the two breakends of a paired adjacency, or `None` for a single one.
+fn paired_breakends<N: Nucleotide>(adjacency: &Adjacency<N>) -> Option<(&Breakend, &Breakend)> {
+    adjacency.paired().map(|(a, b, _)| (a, b))
+}
+
+/// Reports whether every breakend across the adjacencies is on one contig.
+///
+/// A single-ended adjacency has no second known locus, so its presence makes
+/// the answer `false`.
+fn one_contig<N: Nucleotide>(adjacencies: &[&Adjacency<N>]) -> bool {
+    let mut contig: Option<&str> = None;
+    for adjacency in adjacencies {
+        let Some((a, b)) = paired_breakends(adjacency) else {
+            return false;
+        };
+        for breakend in [a, b] {
+            match contig {
+                None => contig = Some(breakend.contig().as_str()),
+                Some(seen) if seen != breakend.contig().as_str() => return false,
+                Some(_) => {}
+            }
+        }
+    }
+    true
+}
+
+/// Gets the shared orientation of a fold-back adjacency, or `None` otherwise.
+///
+/// A fold-back is a paired adjacency whose two breakends share an orientation.
+fn fold_back_orientation<N: Nucleotide>(adjacency: &Adjacency<N>) -> Option<Orientation> {
+    match paired_breakends(adjacency) {
+        Some((a, b)) if a.orientation() == b.orientation() => Some(a.orientation()),
+        _ => None,
+    }
+}
+
+/// Gets the sorted pair of interbase positions of a paired adjacency.
+fn position_pair<N: Nucleotide>(adjacency: &Adjacency<N>) -> Option<(Number, Number)> {
+    let (a, b) = paired_breakends(adjacency)?;
+    let (lo, hi) = (a.position().get(), b.position().get());
+    Some(if lo <= hi { (lo, hi) } else { (hi, lo) })
+}
+
 /// Classifies a structural variant made of exactly one adjacency.
 fn classify_single<N: Nucleotide>(adjacency: &Adjacency<N>) -> Kind {
     let Some((a, b, _)) = adjacency.paired() else {
@@ -211,6 +255,86 @@ fn classify_single<N: Nucleotide>(adjacency: &Adjacency<N>) -> Kind {
                 Kind::Deletion
             }
         }
+    }
+}
+
+/// Classifies a two-adjacency event.
+///
+/// An inversion is exactly two paired fold-back adjacencies on one contig over
+/// the same two boundary positions, one both-`LowerFlank` and one
+/// both-`HigherFlank`. Anything else is [`Kind::Complex`].
+fn classify_pair<N: Nucleotide>(first: &Adjacency<N>, second: &Adjacency<N>) -> Kind {
+    if !one_contig(&[first, second]) {
+        return Kind::Complex;
+    }
+
+    let orientations = (fold_back_orientation(first), fold_back_orientation(second));
+    let positions = (position_pair(first), position_pair(second));
+    if let ((Some(one), Some(two)), (Some(p1), Some(p2))) = (orientations, positions) {
+        if one.is_opposite(two) && p1 == p2 {
+            return Kind::Inversion;
+        }
+    }
+
+    Kind::Complex
+}
+
+/// Classifies a three-adjacency event.
+///
+/// The only recognized signature is the balanced forward intrachromosomal
+/// relocation, namely three paired co-linear (opposite-orientation) junctions
+/// on one contig forming a triangle over exactly three distinct boundaries,
+/// where each boundary appears exactly once as a `LowerFlank` and exactly once
+/// as a `HigherFlank` across the three junctions. Anything else, including a
+/// triple that reuses a flank or one with a fold-back, is [`Kind::Complex`].
+fn classify_triple<N: Nucleotide>(
+    first: &Adjacency<N>,
+    second: &Adjacency<N>,
+    third: &Adjacency<N>,
+) -> Kind {
+    let adjacencies = [first, second, third];
+    if !one_contig(&adjacencies) {
+        return Kind::Complex;
+    }
+
+    // Every junction must be a co-linear (opposite-orientation) paired join.
+    for adjacency in adjacencies {
+        match paired_breakends(adjacency) {
+            Some((a, b)) if a.orientation().is_opposite(b.orientation()) => {}
+            _ => return Kind::Complex,
+        }
+    }
+
+    // Tally, per boundary position, how often it appears as a `LowerFlank` and
+    // as a `HigherFlank`. The triangle requires exactly three distinct
+    // boundaries, each appearing once as each flank.
+    let mut counts: Vec<(Number, usize, usize)> = Vec::new();
+    for adjacency in adjacencies {
+        if let Some((a, b)) = paired_breakends(adjacency) {
+            for breakend in [a, b] {
+                let position = breakend.position().get();
+                if !counts.iter().any(|(p, _, _)| *p == position) {
+                    counts.push((position, 0, 0));
+                }
+                let entry = counts
+                    .iter_mut()
+                    .find(|(p, _, _)| *p == position)
+                    .expect("the position was just inserted");
+                match breakend.orientation() {
+                    Orientation::LowerFlank => entry.1 += 1,
+                    Orientation::HigherFlank => entry.2 += 1,
+                }
+            }
+        }
+    }
+
+    let triangle =
+        counts.len() == 3 && counts.iter().all(|(_, lower, higher)| *lower == 1 && *higher == 1);
+
+    if triangle {
+        Kind::Translocation(Locality::Intrachromosomal)
+    } else {
+        Kind::Complex
     }
 }
 
@@ -298,5 +422,137 @@ mod tests {
             ".",
         );
         assert_eq!(Sv::try_new(vec![adjacency]).unwrap().kind(), Kind::Complex);
+    }
+
+    #[test]
+    fn it_classifies_an_inversion() {
+        // Two fold-back junctions over the same two boundaries {100, 200}, one
+        // both-LowerFlank and one both-HigherFlank.
+        let lower = paired(
+            bnd(Orientation::LowerFlank, 100),
+            bnd(Orientation::LowerFlank, 200),
+            ".",
+        );
+        let higher = paired(
+            bnd(Orientation::HigherFlank, 100),
+            bnd(Orientation::HigherFlank, 200),
+            ".",
+        );
+        assert_eq!(
+            Sv::try_new(vec![lower, higher]).unwrap().kind(),
+            Kind::Inversion
+        );
+    }
+
+    #[test]
+    fn it_classifies_an_intrachromosomal_translocation() {
+        // Three co-linear junctions over boundaries {100, 200, 400}, forming a
+        // triangle where each boundary appears once as each flank.
+        let origin = paired(
+            bnd(Orientation::LowerFlank, 100),
+            bnd(Orientation::HigherFlank, 200),
+            ".",
+        );
+        let target_left = paired(
+            bnd(Orientation::LowerFlank, 400),
+            bnd(Orientation::HigherFlank, 100),
+            ".",
+        );
+        let target_right = paired(
+            bnd(Orientation::LowerFlank, 200),
+            bnd(Orientation::HigherFlank, 400),
+            ".",
+        );
+        assert_eq!(
+            Sv::try_new(vec![origin, target_left, target_right])
+                .unwrap()
+                .kind(),
+            Kind::Translocation(Locality::Intrachromosomal)
+        );
+    }
+
+    #[test]
+    fn it_classifies_two_unrelated_fold_backs_as_complex() {
+        let one = paired(
+            bnd(Orientation::LowerFlank, 100),
+            bnd(Orientation::LowerFlank, 200),
+            ".",
+        );
+        let two = paired(
+            bnd(Orientation::LowerFlank, 300),
+            bnd(Orientation::LowerFlank, 400),
+            ".",
+        );
+        assert_eq!(Sv::try_new(vec![one, two]).unwrap().kind(), Kind::Complex);
+    }
+
+    #[test]
+    fn it_rejects_a_triple_that_reuses_a_flank_as_complex() {
+        // Three co-linear junctions over three distinct boundaries {100, 200,
+        // 300}, each appearing twice overall, but 100 appears twice as a
+        // LowerFlank and never as a HigherFlank, so it is not a proper triangle.
+        let one = paired(
+            bnd(Orientation::LowerFlank, 100),
+            bnd(Orientation::HigherFlank, 200),
+            ".",
+        );
+        let two = paired(
+            bnd(Orientation::LowerFlank, 100),
+            bnd(Orientation::HigherFlank, 300),
+            ".",
+        );
+        let three = paired(
+            bnd(Orientation::LowerFlank, 200),
+            bnd(Orientation::HigherFlank, 300),
+            ".",
+        );
+        assert_eq!(
+            Sv::try_new(vec![one, two, three]).unwrap().kind(),
+            Kind::Complex
+        );
+    }
+
+    #[test]
+    fn it_normalizes_a_permuted_adjacency_list() {
+        let lower = paired(
+            bnd(Orientation::LowerFlank, 100),
+            bnd(Orientation::LowerFlank, 200),
+            ".",
+        );
+        let higher = paired(
+            bnd(Orientation::HigherFlank, 100),
+            bnd(Orientation::HigherFlank, 200),
+            ".",
+        );
+
+        let canonical = Sv::try_new(vec![lower.clone(), higher.clone()]).unwrap();
+        let permuted = Sv::try_new(vec![higher, lower]).unwrap();
+
+        assert_eq!(canonical, permuted);
+        assert_eq!(canonical.kind(), permuted.kind());
+        assert_eq!(permuted.kind(), Kind::Inversion);
+    }
+
+    #[test]
+    fn it_normalizes_a_duplicate_adjacency_list() {
+        let lower = paired(
+            bnd(Orientation::LowerFlank, 100),
+            bnd(Orientation::LowerFlank, 200),
+            ".",
+        );
+        let higher = paired(
+            bnd(Orientation::HigherFlank, 100),
+            bnd(Orientation::HigherFlank, 200),
+            ".",
+        );
+
+        let canonical = Sv::try_new(vec![lower.clone(), higher.clone()]).unwrap();
+        let with_duplicate = Sv::try_new(vec![lower, higher.clone(), higher]).unwrap();
+
+        assert_eq!(canonical, with_duplicate);
+        assert_eq!(canonical.adjacencies().len(), 2);
+        assert_eq!(with_duplicate.adjacencies().len(), 2);
+        assert_eq!(canonical.kind(), with_duplicate.kind());
+        assert_eq!(with_duplicate.kind(), Kind::Inversion);
     }
 }

--- a/omics-variation/src/structural.rs
+++ b/omics-variation/src/structural.rs
@@ -338,7 +338,13 @@ fn classify_pair<N: Nucleotide>(first: &Adjacency<N>, second: &Adjacency<N>) -> 
     let orientations = (fold_back_orientation(first), fold_back_orientation(second));
     let positions = (position_pair(first), position_pair(second));
     if let ((Some(one), Some(two)), (Some(p1), Some(p2))) = (orientations, positions) {
-        if one.is_opposite(two) && p1 == p2 {
+        // The shared boundary pair must span two distinct positions. A pair
+        // with `lo == hi` is a zero-length fold-back that cannot form a real
+        // inversion, so it falls through to `Kind::Complex`. With the
+        // self-junction rejection in `Adjacency::try_new_paired`, such a pair is
+        // already unconstructable, so this guard is defense-in-depth.
+        let (lo, hi) = p1;
+        if one.is_opposite(two) && p1 == p2 && lo != hi {
             return Kind::Inversion;
         }
     }
@@ -514,6 +520,27 @@ mod tests {
         let higher = paired(
             bnd(Orientation::HigherFlank, 100),
             bnd(Orientation::HigherFlank, 200),
+            ".",
+        );
+        assert_eq!(
+            Sv::try_new(vec![lower, higher]).unwrap().kind(),
+            Kind::Inversion
+        );
+    }
+
+    #[test]
+    fn it_classifies_a_genuine_inversion_over_distinct_boundaries() {
+        // Two fold-back junctions over two distinct boundaries {100, 300}, one
+        // both-LowerFlank and one both-HigherFlank. The distinct-position guard
+        // in `classify_pair` is satisfied, so this classifies as an inversion.
+        let lower = paired(
+            bnd(Orientation::LowerFlank, 100),
+            bnd(Orientation::LowerFlank, 300),
+            ".",
+        );
+        let higher = paired(
+            bnd(Orientation::HigherFlank, 100),
+            bnd(Orientation::HigherFlank, 300),
             ".",
         );
         assert_eq!(

--- a/omics-variation/src/structural.rs
+++ b/omics-variation/src/structural.rs
@@ -3,3 +3,300 @@
 pub mod adjacency;
 pub mod breakend;
 pub mod orientation;
+
+use omics_coordinate::position::Number;
+use omics_molecule::compound::Nucleotide;
+use thiserror::Error;
+
+use crate::structural::adjacency::Adjacency;
+use crate::structural::breakend::Breakend;
+use crate::structural::orientation::Orientation;
+
+/// Whether a translocation stays on one contig or crosses contigs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Locality {
+    /// The translocation crosses two contigs.
+    Interchromosomal,
+
+    /// The translocation stays on one contig.
+    Intrachromosomal,
+}
+
+/// The derived class of a structural variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Kind {
+    /// A large deletion.
+    Deletion,
+
+    /// A large insertion.
+    Insertion,
+
+    /// An internal tandem duplication.
+    TandemDuplication,
+
+    /// An inversion.
+    Inversion,
+
+    /// A translocation, with its locality.
+    Translocation(Locality),
+
+    /// A single-ended breakend joined to novel sequence.
+    Breakend,
+
+    /// A well-formed event whose shape matches no named pattern.
+    Complex,
+}
+
+/// An error related to constructing a [`StructuralVariant`].
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum Error {
+    /// The event held no adjacencies.
+    #[error("a structural variant must hold at least one adjacency")]
+    Empty,
+}
+
+/// A structural variant, built from one or more novel adjacencies.
+///
+/// The adjacencies are held in a normalized form, sorted by a deterministic
+/// canonical key and deduplicated, so that equality and classification do not
+/// depend on the input order and are insensitive to duplicates.
+///
+/// `Hash` is intentionally not derived because `Adjacency` does not implement
+/// it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StructuralVariant<N: Nucleotide> {
+    /// The adjacencies making up the event, held in normalized order.
+    adjacencies: Vec<Adjacency<N>>,
+}
+
+impl<N: Nucleotide> StructuralVariant<N> {
+    /// Attempts to create a new [`StructuralVariant`].
+    ///
+    /// The supplied adjacencies are normalized, meaning they are sorted by a
+    /// deterministic canonical key and deduplicated. As a result, a permuted or
+    /// duplicate-bearing input compares equal to its canonical form and
+    /// classifies identically.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use omics_molecule::polymer::dna;
+    /// use omics_variation::structural::StructuralVariant;
+    /// use omics_variation::structural::adjacency::Adjacency;
+    /// use omics_variation::structural::breakend::Breakend;
+    /// use omics_variation::structural::orientation::Orientation;
+    ///
+    /// let a = Breakend::try_new("seq0", Orientation::LowerFlank, 100)?;
+    /// let b = Breakend::try_new("seq0", Orientation::HigherFlank, 200)?;
+    /// let adjacency = Adjacency::<dna::Nucleotide>::try_new_paired(a, b, ".".parse()?)?;
+    /// let variant = StructuralVariant::try_new(vec![adjacency])?;
+    /// assert_eq!(variant.adjacencies().len(), 1);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn try_new(mut adjacencies: Vec<Adjacency<N>>) -> Result<Self, Error> {
+        if adjacencies.is_empty() {
+            return Err(Error::Empty);
+        }
+
+        adjacencies.sort_by_key(|adjacency| adjacency_key(adjacency));
+        adjacencies.dedup();
+
+        Ok(Self { adjacencies })
+    }
+
+    /// Gets the adjacencies of this structural variant.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use omics_molecule::polymer::dna;
+    /// use omics_variation::structural::StructuralVariant;
+    /// use omics_variation::structural::adjacency::Adjacency;
+    /// use omics_variation::structural::breakend::Breakend;
+    /// use omics_variation::structural::orientation::Orientation;
+    ///
+    /// let a = Breakend::try_new("seq0", Orientation::LowerFlank, 100)?;
+    /// let b = Breakend::try_new("seq0", Orientation::HigherFlank, 200)?;
+    /// let adjacency = Adjacency::<dna::Nucleotide>::try_new_paired(a, b, ".".parse()?)?;
+    /// let variant = StructuralVariant::try_new(vec![adjacency])?;
+    /// assert_eq!(variant.adjacencies().len(), 1);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn adjacencies(&self) -> &[Adjacency<N>] {
+        &self.adjacencies
+    }
+
+    /// Derives the [`Kind`] of this structural variant from its geometry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use omics_molecule::polymer::dna;
+    /// use omics_variation::structural::Kind;
+    /// use omics_variation::structural::StructuralVariant;
+    /// use omics_variation::structural::adjacency::Adjacency;
+    /// use omics_variation::structural::breakend::Breakend;
+    /// use omics_variation::structural::orientation::Orientation;
+    ///
+    /// let a = Breakend::try_new("seq0", Orientation::LowerFlank, 100)?;
+    /// let b = Breakend::try_new("seq0", Orientation::HigherFlank, 200)?;
+    /// let adjacency = Adjacency::<dna::Nucleotide>::try_new_paired(a, b, ".".parse()?)?;
+    /// let variant = StructuralVariant::try_new(vec![adjacency])?;
+    /// assert_eq!(variant.kind(), Kind::Deletion);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn kind(&self) -> Kind {
+        match self.adjacencies.as_slice() {
+            [single] => classify_single(single),
+            // Multi-adjacency classification is added in the next task.
+            _ => Kind::Complex,
+        }
+    }
+}
+
+/// An owned canonical ordering key for a single breakend.
+///
+/// It mirrors [`Breakend::canonical_key`] but owns its contig so it can back a
+/// sortable key for a whole adjacency.
+type BreakendKey = (String, Number, u8);
+
+/// Gets the owned canonical ordering key for a breakend.
+fn breakend_key(breakend: &Breakend) -> BreakendKey {
+    let (contig, position, rank) = breakend.canonical_key();
+    (contig.to_string(), position, rank)
+}
+
+/// Gets the deterministic canonical ordering key for an adjacency.
+///
+/// The key tags paired adjacencies ahead of single ones, then orders by the
+/// canonical breakend keys and finally by the insertion sequence. It backs the
+/// normalized ordering of the adjacencies in a [`StructuralVariant`].
+fn adjacency_key<N: Nucleotide>(adjacency: &Adjacency<N>) -> (u8, BreakendKey, BreakendKey, String) {
+    if let Some((a, b, insertion)) = adjacency.paired() {
+        (0, breakend_key(a), breakend_key(b), insertion.to_string())
+    } else if let Some((breakend, insertion)) = adjacency.single() {
+        (
+            1,
+            breakend_key(breakend),
+            (String::new(), 0, 0),
+            insertion.to_string(),
+        )
+    } else {
+        unreachable!("an adjacency is always paired or single")
+    }
+}
+
+/// Classifies a structural variant made of exactly one adjacency.
+fn classify_single<N: Nucleotide>(adjacency: &Adjacency<N>) -> Kind {
+    let Some((a, b, _)) = adjacency.paired() else {
+        // A single-ended breakend.
+        return Kind::Breakend;
+    };
+
+    if a.contig() != b.contig() {
+        return Kind::Translocation(Locality::Interchromosomal);
+    }
+
+    if !a.orientation().is_opposite(b.orientation()) {
+        // A lone fold-back is an incomplete inversion.
+        return Kind::Complex;
+    }
+
+    match a.orientation() {
+        Orientation::HigherFlank => Kind::TandemDuplication,
+        Orientation::LowerFlank => {
+            if a.position().get() == b.position().get() {
+                Kind::Insertion
+            } else {
+                Kind::Deletion
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use omics_coordinate::position::Number;
+    use omics_molecule::polymer::dna;
+
+    use super::*;
+    use crate::structural::adjacency::Adjacency;
+    use crate::structural::breakend::Breakend;
+    use crate::structural::orientation::Orientation;
+
+    type Sv = StructuralVariant<dna::Nucleotide>;
+
+    fn bnd(orientation: Orientation, position: Number) -> Breakend {
+        Breakend::try_new("seq0", orientation, position).unwrap()
+    }
+
+    fn paired(x: Breakend, y: Breakend, insertion: &str) -> Adjacency<dna::Nucleotide> {
+        Adjacency::try_new_paired(x, y, insertion.parse().unwrap()).unwrap()
+    }
+
+    #[test]
+    fn it_rejects_an_empty_event() {
+        assert!(matches!(Sv::try_new(Vec::new()), Err(Error::Empty)));
+    }
+
+    #[test]
+    fn it_classifies_a_deletion() {
+        let adjacency = paired(
+            bnd(Orientation::LowerFlank, 100),
+            bnd(Orientation::HigherFlank, 200),
+            ".",
+        );
+        assert_eq!(Sv::try_new(vec![adjacency]).unwrap().kind(), Kind::Deletion);
+    }
+
+    #[test]
+    fn it_classifies_a_tandem_duplication() {
+        let adjacency = paired(
+            bnd(Orientation::HigherFlank, 100),
+            bnd(Orientation::LowerFlank, 200),
+            ".",
+        );
+        assert_eq!(
+            Sv::try_new(vec![adjacency]).unwrap().kind(),
+            Kind::TandemDuplication
+        );
+    }
+
+    #[test]
+    fn it_classifies_a_large_insertion() {
+        let adjacency = paired(
+            bnd(Orientation::LowerFlank, 100),
+            bnd(Orientation::HigherFlank, 100),
+            "AAAA",
+        );
+        assert_eq!(Sv::try_new(vec![adjacency]).unwrap().kind(), Kind::Insertion);
+    }
+
+    #[test]
+    fn it_classifies_an_interchromosomal_translocation() {
+        let a = Breakend::try_new("seq0", Orientation::LowerFlank, 100).unwrap();
+        let b = Breakend::try_new("seq1", Orientation::HigherFlank, 200).unwrap();
+        let adjacency = Adjacency::try_new_paired(a, b, ".".parse().unwrap()).unwrap();
+        assert_eq!(
+            Sv::try_new(vec![adjacency]).unwrap().kind(),
+            Kind::Translocation(Locality::Interchromosomal)
+        );
+    }
+
+    #[test]
+    fn it_classifies_a_single_ended_breakend() {
+        let breakend = bnd(Orientation::LowerFlank, 100);
+        let adjacency = Adjacency::new_single(breakend, "AT".parse().unwrap());
+        assert_eq!(Sv::try_new(vec![adjacency]).unwrap().kind(), Kind::Breakend);
+    }
+
+    #[test]
+    fn it_classifies_a_lone_fold_back_as_complex() {
+        let adjacency = paired(
+            bnd(Orientation::LowerFlank, 100),
+            bnd(Orientation::LowerFlank, 200),
+            ".",
+        );
+        assert_eq!(Sv::try_new(vec![adjacency]).unwrap().kind(), Kind::Complex);
+    }
+}

--- a/omics-variation/src/structural.rs
+++ b/omics-variation/src/structural.rs
@@ -297,10 +297,16 @@ fn classify_triple<N: Nucleotide>(
         return Kind::Complex;
     }
 
-    // Every junction must be a co-linear (opposite-orientation) paired join.
+    // Every junction must be a co-linear (opposite-orientation) paired join
+    // that is not a self-loop. A self-loop (both breakends at the same
+    // boundary) is a degenerate join that cannot participate in a connected
+    // triangle, so any such junction demotes the triple to complex even when
+    // the per-boundary flank tally would otherwise be satisfied.
     for adjacency in adjacencies {
         match paired_breakends(adjacency) {
-            Some((a, b)) if a.orientation().is_opposite(b.orientation()) => {}
+            Some((a, b))
+                if a.orientation().is_opposite(b.orientation())
+                    && a.position().get() != b.position().get() => {}
             _ => return Kind::Complex,
         }
     }
@@ -508,6 +514,60 @@ mod tests {
         );
         assert_eq!(
             Sv::try_new(vec![one, two, three]).unwrap().kind(),
+            Kind::Complex
+        );
+    }
+
+    #[test]
+    fn it_rejects_three_self_loop_junctions_as_complex() {
+        // Three independent self-loop insertions. Each junction's two breakends
+        // sit at the same position, so the graph is three disconnected
+        // self-loops rather than a connected triangle. Although the per-boundary
+        // flank tally is satisfied, this must classify as Complex, not an
+        // intrachromosomal translocation.
+        let j1 = paired(
+            bnd(Orientation::LowerFlank, 100),
+            bnd(Orientation::HigherFlank, 100),
+            "A",
+        );
+        let j2 = paired(
+            bnd(Orientation::LowerFlank, 200),
+            bnd(Orientation::HigherFlank, 200),
+            "A",
+        );
+        let j3 = paired(
+            bnd(Orientation::LowerFlank, 300),
+            bnd(Orientation::HigherFlank, 300),
+            "A",
+        );
+        assert_eq!(
+            Sv::try_new(vec![j1, j2, j3]).unwrap().kind(),
+            Kind::Complex
+        );
+    }
+
+    #[test]
+    fn it_rejects_an_inverted_reinsertion_as_complex() {
+        // A three-junction set where one junction is a fold-back (both breakends
+        // share the same orientation). The co-linear check rejects any triple
+        // containing a fold-back, so this classifies as Complex.
+        let fold_back = paired(
+            bnd(Orientation::LowerFlank, 100),
+            bnd(Orientation::LowerFlank, 200),
+            ".",
+        );
+        let two = paired(
+            bnd(Orientation::LowerFlank, 400),
+            bnd(Orientation::HigherFlank, 100),
+            ".",
+        );
+        let three = paired(
+            bnd(Orientation::LowerFlank, 200),
+            bnd(Orientation::HigherFlank, 400),
+            ".",
+        );
+        assert_eq!(
+            Sv::try_new(vec![fold_back, two, three]).unwrap().kind(),
             Kind::Complex
         );
     }

--- a/omics-variation/src/structural.rs
+++ b/omics-variation/src/structural.rs
@@ -301,23 +301,28 @@ fn breakend_key(breakend: &Breakend) -> BreakendKey {
 fn adjacency_key<N: Nucleotide>(
     adjacency: &Adjacency<N>,
 ) -> (u8, BreakendKey, BreakendKey, String) {
-    if let Some((a, b, insertion)) = adjacency.paired() {
-        (0, breakend_key(a), breakend_key(b), insertion.to_string())
-    } else if let Some((breakend, insertion)) = adjacency.single() {
-        (
+    match adjacency {
+        Adjacency::Paired(paired) => (
+            0,
+            breakend_key(paired.a()),
+            breakend_key(paired.b()),
+            paired.insertion().to_string(),
+        ),
+        Adjacency::Single(single) => (
             1,
-            breakend_key(breakend),
+            breakend_key(single.breakend()),
             (String::new(), 0, 0),
-            insertion.to_string(),
-        )
-    } else {
-        unreachable!("an adjacency is always paired or single")
+            single.insertion().to_string(),
+        ),
     }
 }
 
 /// Gets the two breakends of a paired adjacency, or `None` for a single one.
 fn paired_breakends<N: Nucleotide>(adjacency: &Adjacency<N>) -> Option<(&Breakend, &Breakend)> {
-    adjacency.paired().map(|(a, b, _)| (a, b))
+    match adjacency {
+        Adjacency::Paired(paired) => Some((paired.a(), paired.b())),
+        Adjacency::Single(_) => None,
+    }
 }
 
 /// Reports whether every breakend across the adjacencies is on one contig.
@@ -360,10 +365,11 @@ fn position_pair<N: Nucleotide>(adjacency: &Adjacency<N>) -> Option<(Number, Num
 
 /// Classifies a structural variant made of exactly one adjacency.
 fn classify_single<N: Nucleotide>(adjacency: &Adjacency<N>) -> Kind {
-    let Some((a, b, _)) = adjacency.paired() else {
+    let Adjacency::Paired(paired) = adjacency else {
         // A single-ended breakend.
         return Kind::Breakend;
     };
+    let (a, b) = (paired.a(), paired.b());
 
     if a.contig() != b.contig() {
         return Kind::Translocation(Locality::Interchromosomal);

--- a/omics-variation/src/structural.rs
+++ b/omics-variation/src/structural.rs
@@ -750,6 +750,13 @@ mod tests {
     }
 
     #[test]
+    fn it_round_trips_a_single_ended_breakend() {
+        let adjacency =
+            Adjacency::new_single(bnd(Orientation::LowerFlank, 100), "AT".parse().unwrap());
+        round_trip(Sv::try_new(vec![adjacency]).unwrap(), Kind::Breakend);
+    }
+
+    #[test]
     fn it_rejects_an_empty_string() {
         let err = "".parse::<Sv>().unwrap_err();
         assert!(matches!(err, ParseError::Empty));

--- a/omics-variation/src/structural.rs
+++ b/omics-variation/src/structural.rs
@@ -1,4 +1,5 @@
 //! The structural-variant tier.
 
+pub mod adjacency;
 pub mod breakend;
 pub mod orientation;

--- a/omics-variation/src/structural.rs
+++ b/omics-variation/src/structural.rs
@@ -60,6 +60,91 @@
 //! whether a whole event is balanced. A reciprocal event that yields more than
 //! one derivative molecule is several adjacencies grouped in a
 //! [`StructuralVariant`].
+//!
+//! # Reading the kinds
+//!
+//! The figures below show how each [`Kind`] looks in the data model. In them
+//! `>` marks a lower-flank breakend and `<` marks a higher-flank one, the same
+//! glyphs the serialized form uses. Positions are interbase boundaries, `::`
+//! separates the fields of one adjacency, and `;` separates the adjacencies of
+//! one event. A `.` is an empty insertion or, in the middle field, the open
+//! side of a single-ended breakend.
+//!
+//! A deletion is one co-linear junction whose lower breakend keeps its lower
+//! flank, so the two outer pieces join and the middle is dropped.
+//!
+//! ```text
+//! ref   ==A==|100 .......... 5000|==B==
+//! adj   seq0:>:100(i)::seq0:<:5000(i)::.
+//! =>    ==A====B==                 Deletion  (101..5000 removed)
+//! ```
+//!
+//! A large insertion is one co-linear junction at a single boundary carrying
+//! the novel bases.
+//!
+//! ```text
+//! ref   ==A==|100|==B==
+//! adj   seq0:>:100(i)::seq0:<:100(i)::ACGT
+//! =>    ==A==[ACGT]==B==            Insertion
+//! ```
+//!
+//! A tandem duplication is one co-linear junction whose lower breakend keeps
+//! its higher flank, so the join runs backward and the segment repeats.
+//!
+//! ```text
+//! ref   ==| 100 ==seg== 160 |==
+//! adj   seq0:<:100(i)::seq0:>:160(i)::GAT
+//! =>    ==|100 ==seg== 160||100 ==seg== 160|==   TandemDuplication
+//! ```
+//!
+//! An inversion is two fold-back junctions over the same two boundaries, one
+//! joining the lower flanks and one joining the higher flanks.
+//!
+//! ```text
+//! ref   ==| 100 ==seg== 300 |==
+//! adj   seq0:>:100(i)::seq0:>:300(i)::. ; seq0:<:100(i)::seq0:<:300(i)::.
+//! =>    ==| revcomp(seg) |==            Inversion
+//! ```
+//!
+//! An interchromosomal translocation is one junction across two contigs. With
+//! opposite orientations the fused piece keeps its direction.
+//!
+//! ```text
+//! ref   seq0 ==A==|100        seq1 900|==B==
+//! adj   seq0:>:100(i)::seq1:<:900(i)::.
+//! =>    ==A==|==B==            Translocation { Interchromosomal, CoLinear }
+//! ```
+//!
+//! With matching orientations the fused piece is reverse-complemented, a
+//! fold-back.
+//!
+//! ```text
+//! adj   seq0:>:100(i)::seq1:>:200(i)::.
+//! =>    ==A==| revcomp(seq1 piece)      Translocation { Interchromosomal, FoldBack }
+//! ```
+//!
+//! An intrachromosomal translocation is the balanced forward relocation of a
+//! segment, three co-linear junctions over three boundaries where each boundary
+//! appears once as a lower flank and once as a higher flank.
+//!
+//! ```text
+//! adj   seq0:>:100(i)::seq0:<:200(i)::.     origin flanks rejoin
+//!       seq0:<:100(i)::seq0:>:400(i)::.     segment start meets the target
+//!       seq0:>:200(i)::seq0:<:400(i)::.     segment end meets the target
+//! =>    Translocation { Intrachromosomal, CoLinear }
+//! ```
+//!
+//! A single-ended breakend joins one locus to novel or unassembled sequence,
+//! with the other side open.
+//!
+//! ```text
+//! ref   ==A==|100  ->  novel sequence
+//! adj   seq0:>:100(i)::.::AT
+//! =>    Breakend
+//! ```
+//!
+//! Any well-formed event whose shape matches none of these, such as a lone
+//! fold-back or a reciprocal interchromosomal pair, is [`Kind::Complex`].
 
 pub mod adjacency;
 pub mod breakend;

--- a/omics-variation/src/structural.rs
+++ b/omics-variation/src/structural.rs
@@ -4,13 +4,20 @@ pub mod adjacency;
 pub mod breakend;
 pub mod orientation;
 
+use std::fmt;
+use std::str::FromStr;
+
 use omics_coordinate::position::Number;
+use omics_molecule::compound::Complement;
 use omics_molecule::compound::Nucleotide;
 use thiserror::Error;
 
 use crate::structural::adjacency::Adjacency;
 use crate::structural::breakend::Breakend;
 use crate::structural::orientation::Orientation;
+
+/// The separator between the adjacency tokens of a [`StructuralVariant`].
+const EVENT_SEPARATOR: &str = ";";
 
 /// Whether a translocation stays on one contig or crosses contigs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -55,6 +62,22 @@ pub enum Error {
     Empty,
 }
 
+/// A parse error related to a [`StructuralVariant`].
+#[derive(Error, Debug)]
+pub enum ParseError {
+    /// The structural-variant string was empty.
+    #[error("a structural variant string must not be empty")]
+    Empty,
+
+    /// An adjacency token failed to parse.
+    #[error(transparent)]
+    Adjacency(#[from] adjacency::ParseError),
+
+    /// The structural variant could not be constructed.
+    #[error(transparent)]
+    Construct(#[from] Error),
+}
+
 /// A structural variant, built from one or more novel adjacencies.
 ///
 /// The adjacencies are held in a normalized form, sorted by a deterministic
@@ -63,6 +86,20 @@ pub enum Error {
 ///
 /// `Hash` is intentionally not derived because `Adjacency` does not implement
 /// it.
+///
+/// A structural variant serializes as its adjacency tokens joined with `;`.
+///
+/// # Examples
+///
+/// ```
+/// use omics_molecule::polymer::dna;
+/// use omics_variation::structural::StructuralVariant;
+///
+/// let rendered = "seq0:>:100(i)::seq0:<:200(i)::.";
+/// let variant = rendered.parse::<StructuralVariant<dna::Nucleotide>>()?;
+/// assert_eq!(variant.to_string(), rendered);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StructuralVariant<N: Nucleotide> {
     /// The adjacencies making up the event, held in normalized order.
@@ -152,6 +189,34 @@ impl<N: Nucleotide> StructuralVariant<N> {
             [first, second, third] => classify_triple(first, second, third),
             _ => Kind::Complex,
         }
+    }
+}
+
+impl<N: Nucleotide> fmt::Display for StructuralVariant<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let tokens = self
+            .adjacencies
+            .iter()
+            .map(|adjacency| adjacency.to_string())
+            .collect::<Vec<_>>();
+        write!(f, "{}", tokens.join(EVENT_SEPARATOR))
+    }
+}
+
+impl<N: Nucleotide + Complement> FromStr for StructuralVariant<N> {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err(ParseError::Empty);
+        }
+
+        let adjacencies = s
+            .split(EVENT_SEPARATOR)
+            .map(|token| token.parse::<Adjacency<N>>())
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(StructuralVariant::try_new(adjacencies)?)
     }
 }
 
@@ -591,6 +656,109 @@ mod tests {
         assert_eq!(canonical, permuted);
         assert_eq!(canonical.kind(), permuted.kind());
         assert_eq!(permuted.kind(), Kind::Inversion);
+    }
+
+    fn round_trip(variant: Sv, expected: Kind) {
+        assert_eq!(variant.kind(), expected);
+        let rendered = variant.to_string();
+        let parsed = rendered.parse::<Sv>().unwrap();
+        assert_eq!(parsed, variant);
+        assert_eq!(parsed.kind(), variant.kind());
+        assert_eq!(parsed.to_string(), rendered);
+    }
+
+    #[test]
+    fn it_round_trips_a_large_deletion() {
+        let adjacency = paired(
+            bnd(Orientation::LowerFlank, 100),
+            bnd(Orientation::HigherFlank, 200),
+            ".",
+        );
+        round_trip(Sv::try_new(vec![adjacency]).unwrap(), Kind::Deletion);
+    }
+
+    #[test]
+    fn it_round_trips_a_large_insertion() {
+        let adjacency = paired(
+            bnd(Orientation::LowerFlank, 100),
+            bnd(Orientation::HigherFlank, 100),
+            "AAAA",
+        );
+        round_trip(Sv::try_new(vec![adjacency]).unwrap(), Kind::Insertion);
+    }
+
+    #[test]
+    fn it_round_trips_an_interchromosomal_translocation() {
+        let a = Breakend::try_new("seq0", Orientation::LowerFlank, 100).unwrap();
+        let b = Breakend::try_new("seq1", Orientation::HigherFlank, 200).unwrap();
+        let adjacency = Adjacency::try_new_paired(a, b, ".".parse().unwrap()).unwrap();
+        round_trip(
+            Sv::try_new(vec![adjacency]).unwrap(),
+            Kind::Translocation(Locality::Interchromosomal),
+        );
+    }
+
+    #[test]
+    fn it_round_trips_an_intrachromosomal_translocation() {
+        let origin = paired(
+            bnd(Orientation::LowerFlank, 100),
+            bnd(Orientation::HigherFlank, 200),
+            ".",
+        );
+        let target_left = paired(
+            bnd(Orientation::LowerFlank, 400),
+            bnd(Orientation::HigherFlank, 100),
+            ".",
+        );
+        let target_right = paired(
+            bnd(Orientation::LowerFlank, 200),
+            bnd(Orientation::HigherFlank, 400),
+            ".",
+        );
+        round_trip(
+            Sv::try_new(vec![origin, target_left, target_right]).unwrap(),
+            Kind::Translocation(Locality::Intrachromosomal),
+        );
+    }
+
+    #[test]
+    fn it_round_trips_an_inversion() {
+        let lower = paired(
+            bnd(Orientation::LowerFlank, 100),
+            bnd(Orientation::LowerFlank, 200),
+            ".",
+        );
+        let higher = paired(
+            bnd(Orientation::HigherFlank, 100),
+            bnd(Orientation::HigherFlank, 200),
+            ".",
+        );
+        round_trip(Sv::try_new(vec![lower, higher]).unwrap(), Kind::Inversion);
+    }
+
+    #[test]
+    fn it_round_trips_an_internal_tandem_duplication() {
+        let adjacency = paired(
+            bnd(Orientation::HigherFlank, 100),
+            bnd(Orientation::LowerFlank, 200),
+            ".",
+        );
+        round_trip(
+            Sv::try_new(vec![adjacency]).unwrap(),
+            Kind::TandemDuplication,
+        );
+    }
+
+    #[test]
+    fn it_rejects_an_empty_string() {
+        let err = "".parse::<Sv>().unwrap_err();
+        assert!(matches!(err, ParseError::Empty));
+    }
+
+    #[test]
+    fn it_rejects_a_bad_adjacency_token() {
+        let err = "seq0:>:100(i)::AT".parse::<Sv>().unwrap_err();
+        assert!(matches!(err, ParseError::Adjacency(_)));
     }
 
     #[test]

--- a/omics-variation/src/structural.rs
+++ b/omics-variation/src/structural.rs
@@ -90,6 +90,18 @@ pub enum Locality {
     Intrachromosomal,
 }
 
+/// How the two sides of a translocation join with respect to reading direction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Join {
+    /// The two sides read in the same direction, joined without a flip. Its
+    /// breakends have opposite orientations.
+    CoLinear,
+
+    /// One side is reverse-complemented, so the join folds back. Its breakends
+    /// have matching orientations, meaning the fused piece is inverted.
+    FoldBack,
+}
+
 /// The derived class of a structural variant.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Kind {
@@ -105,8 +117,14 @@ pub enum Kind {
     /// An inversion.
     Inversion,
 
-    /// A translocation, with its locality.
-    Translocation(Locality),
+    /// A translocation, with its locality and how its sides join.
+    Translocation {
+        /// Whether the translocation crosses contigs or stays on one.
+        locality: Locality,
+
+        /// Whether the sides join co-linearly or fold back.
+        join: Join,
+    },
 
     /// A single-ended breakend joined to novel sequence.
     Breakend,
@@ -372,7 +390,15 @@ fn classify_single<N: Nucleotide>(adjacency: &Adjacency<N>) -> Kind {
     let (a, b) = (paired.a(), paired.b());
 
     if a.contig() != b.contig() {
-        return Kind::Translocation(Locality::Interchromosomal);
+        let join = if a.orientation().is_opposite(b.orientation()) {
+            Join::CoLinear
+        } else {
+            Join::FoldBack
+        };
+        return Kind::Translocation {
+            locality: Locality::Interchromosomal,
+            join,
+        };
     }
 
     if !a.orientation().is_opposite(b.orientation()) {
@@ -480,7 +506,12 @@ fn classify_triple<N: Nucleotide>(
             .all(|(_, lower, higher)| *lower == 1 && *higher == 1);
 
     if triangle {
-        Kind::Translocation(Locality::Intrachromosomal)
+        // The recognized relocation is three co-linear junctions, so the sides
+        // join co-linearly.
+        Kind::Translocation {
+            locality: Locality::Intrachromosomal,
+            join: Join::CoLinear,
+        }
     } else {
         Kind::Complex
     }
@@ -554,7 +585,26 @@ mod tests {
         let adjacency = Adjacency::try_new_paired(a, b, ".".parse().unwrap()).unwrap();
         assert_eq!(
             Sv::try_new(vec![adjacency]).unwrap().kind(),
-            Kind::Translocation(Locality::Interchromosomal)
+            Kind::Translocation {
+                locality: Locality::Interchromosomal,
+                join: Join::CoLinear
+            }
+        );
+    }
+
+    #[test]
+    fn it_classifies_an_inverted_interchromosomal_translocation() {
+        // Matching orientations across contigs fuse the other contig's piece
+        // reverse-complemented, so the join folds back.
+        let a = Breakend::try_new("seq0", Orientation::LowerFlank, 100).unwrap();
+        let b = Breakend::try_new("seq1", Orientation::LowerFlank, 200).unwrap();
+        let adjacency = Adjacency::try_new_paired(a, b, ".".parse().unwrap()).unwrap();
+        assert_eq!(
+            Sv::try_new(vec![adjacency]).unwrap().kind(),
+            Kind::Translocation {
+                locality: Locality::Interchromosomal,
+                join: Join::FoldBack
+            }
         );
     }
 
@@ -639,7 +689,10 @@ mod tests {
             Sv::try_new(vec![origin, target_left, target_right])
                 .unwrap()
                 .kind(),
-            Kind::Translocation(Locality::Intrachromosomal)
+            Kind::Translocation {
+                locality: Locality::Intrachromosomal,
+                join: Join::CoLinear
+            }
         );
     }
 
@@ -792,7 +845,10 @@ mod tests {
         let adjacency = Adjacency::try_new_paired(a, b, ".".parse().unwrap()).unwrap();
         round_trip(
             Sv::try_new(vec![adjacency]).unwrap(),
-            Kind::Translocation(Locality::Interchromosomal),
+            Kind::Translocation {
+                locality: Locality::Interchromosomal,
+                join: Join::CoLinear,
+            },
         );
     }
 
@@ -815,7 +871,10 @@ mod tests {
         );
         round_trip(
             Sv::try_new(vec![origin, target_left, target_right]).unwrap(),
-            Kind::Translocation(Locality::Intrachromosomal),
+            Kind::Translocation {
+                locality: Locality::Intrachromosomal,
+                join: Join::CoLinear,
+            },
         );
     }
 

--- a/omics-variation/src/structural.rs
+++ b/omics-variation/src/structural.rs
@@ -1,4 +1,43 @@
 //! The structural-variant tier.
+//!
+//! Structural variants are modeled as novel adjacencies between breakends,
+//! following the breakend representation used by the VCF breakend spec and by
+//! GA4GH VRS. A [`Breakend`] is one endpoint of a junction,
+//! an [`Adjacency`] is a single junction joining two
+//! breakends with an optional non-templated insertion, and a
+//! [`StructuralVariant`] is an event built from one or more adjacencies. The
+//! event [`Kind`] is derived from the geometry of those adjacencies rather than
+//! stored, mirroring how the small-variant tier derives its kind from allele
+//! content.
+//!
+//! # Coordinate-anchored orientation
+//!
+//! A breakend carries a contig, an interbase position, and an
+//! [`Orientation`]. It deliberately does not carry a
+//! strand. Every position is a coordinate on the reference, so
+//! [`LowerFlank`](orientation::Orientation::LowerFlank) and
+//! [`HigherFlank`](orientation::Orientation::HigherFlank) name the retained
+//! side purely by reference coordinate, and "lower" can only ever mean a
+//! smaller reference position.
+//!
+//! This deliberately splits two facts that other breakend representations
+//! bundle into a single per-endpoint value. The first fact is which side of the
+//! cut is retained, which lives on the breakend as its
+//! [`Orientation`]. The second fact is the reading
+//! direction of the retained piece in the derivative molecule, or equivalently
+//! whether the join reverse-complements one side. That second fact is stored on
+//! no breakend. It emerges from the pair. Two breakends with opposite
+//! orientations join co-linearly with no flip, while two breakends with
+//! matching orientations form a fold-back that reverse-complements one side,
+//! which is how an inversion arises. The [`Adjacency`]
+//! carries the residual bookkeeping by storing the non-templated insertion in
+//! the reading frame of its canonical first breakend and reverse-complementing
+//! it when the supplied breakends are swapped into canonical order.
+//!
+//! Naming the variants after reference coordinates rather than after a strand
+//! keeps the meaning unambiguous. A single fold-back breakend cannot say on its
+//! own which way its retained piece reads, so a lone fold-back classifies as
+//! [`Kind::Complex`] and only a matched pair resolves an inversion.
 
 pub mod adjacency;
 pub mod breakend;

--- a/omics-variation/src/structural.rs
+++ b/omics-variation/src/structural.rs
@@ -237,7 +237,9 @@ fn breakend_key(breakend: &Breakend) -> BreakendKey {
 /// The key tags paired adjacencies ahead of single ones, then orders by the
 /// canonical breakend keys and finally by the insertion sequence. It backs the
 /// normalized ordering of the adjacencies in a [`StructuralVariant`].
-fn adjacency_key<N: Nucleotide>(adjacency: &Adjacency<N>) -> (u8, BreakendKey, BreakendKey, String) {
+fn adjacency_key<N: Nucleotide>(
+    adjacency: &Adjacency<N>,
+) -> (u8, BreakendKey, BreakendKey, String) {
     if let Some((a, b, insertion)) = adjacency.paired() {
         (0, breakend_key(a), breakend_key(b), insertion.to_string())
     } else if let Some((breakend, insertion)) = adjacency.single() {
@@ -384,12 +386,12 @@ fn classify_triple<N: Nucleotide>(
         if let Some((a, b)) = paired_breakends(adjacency) {
             for breakend in [a, b] {
                 let position = breakend.position().get();
-                if !counts.iter().any(|(p, _, _)| *p == position) {
+                if !counts.iter().any(|(p, ..)| *p == position) {
                     counts.push((position, 0, 0));
                 }
                 let entry = counts
                     .iter_mut()
-                    .find(|(p, _, _)| *p == position)
+                    .find(|(p, ..)| *p == position)
                     .expect("the position was just inserted");
                 match breakend.orientation() {
                     Orientation::LowerFlank => entry.1 += 1,
@@ -399,8 +401,10 @@ fn classify_triple<N: Nucleotide>(
         }
     }
 
-    let triangle =
-        counts.len() == 3 && counts.iter().all(|(_, lower, higher)| *lower == 1 && *higher == 1);
+    let triangle = counts.len() == 3
+        && counts
+            .iter()
+            .all(|(_, lower, higher)| *lower == 1 && *higher == 1);
 
     if triangle {
         Kind::Translocation(Locality::Intrachromosomal)
@@ -464,7 +468,10 @@ mod tests {
             bnd(Orientation::HigherFlank, 100),
             "AAAA",
         );
-        assert_eq!(Sv::try_new(vec![adjacency]).unwrap().kind(), Kind::Insertion);
+        assert_eq!(
+            Sv::try_new(vec![adjacency]).unwrap().kind(),
+            Kind::Insertion
+        );
     }
 
     #[test]
@@ -605,10 +612,7 @@ mod tests {
             bnd(Orientation::HigherFlank, 300),
             "A",
         );
-        assert_eq!(
-            Sv::try_new(vec![j1, j2, j3]).unwrap().kind(),
-            Kind::Complex
-        );
+        assert_eq!(Sv::try_new(vec![j1, j2, j3]).unwrap().kind(), Kind::Complex);
     }
 
     #[test]

--- a/omics-variation/src/structural.rs
+++ b/omics-variation/src/structural.rs
@@ -38,6 +38,28 @@
 //! keeps the meaning unambiguous. A single fold-back breakend cannot say on its
 //! own which way its retained piece reads, so a lone fold-back classifies as
 //! [`Kind::Complex`] and only a matched pair resolves an inversion.
+//!
+//! # Double-stranded reference
+//!
+//! A breakend breaks double-stranded DNA, and a junction fuses one
+//! double-stranded end to another, so both strands join at every adjacency.
+//! Only the reference forward strand is written down. Its antiparallel partner
+//! is left implicit and fuses along with it by Watson-Crick complementarity.
+//!
+//! This is why an orientation pair is enough to place a junction. Once each
+//! side states which flank it retains and whether the join is co-linear or a
+//! fold-back, the way both strands connect is fixed, so the partner-strand
+//! connection is forced rather than separately recorded. A fold-back is exactly
+//! the case where the forward strand of one side continues onto the partner
+//! strand of the other, which is why that side is read reverse-complemented.
+//!
+//! The model therefore assumes a clean fusion of double-stranded ends,
+//! optionally with a non-templated insertion between them. Single-stranded
+//! junctions, and events whose two strands join different partners, are out of
+//! scope. Both strands fusing at one junction is also a separate matter from
+//! whether a whole event is balanced. A reciprocal event that yields more than
+//! one derivative molecule is several adjacencies grouped in a
+//! [`StructuralVariant`].
 
 pub mod adjacency;
 pub mod breakend;

--- a/omics-variation/src/structural.rs
+++ b/omics-variation/src/structural.rs
@@ -1,4 +1,4 @@
-//! The structural-variant tier.
+//! Structural variants.
 //!
 //! Structural variants are modeled as novel adjacencies between breakends,
 //! following the breakend representation used by the VCF breakend spec and by
@@ -7,8 +7,7 @@
 //! breakends with an optional non-templated insertion, and a
 //! [`StructuralVariant`] is an event built from one or more adjacencies. The
 //! event [`Kind`] is derived from the geometry of those adjacencies rather than
-//! stored, mirroring how the small-variant tier derives its kind from allele
-//! content.
+//! stored.
 //!
 //! # Coordinate-anchored orientation
 //!
@@ -107,20 +106,27 @@
 //! ```
 //!
 //! An interchromosomal translocation is one junction across two contigs. With
-//! opposite orientations the fused piece keeps its direction.
+//! opposite orientations the piece brought over from the other contig keeps its
+//! direction. Below, `[R S]` is the segment translocated from `seq1` into the
+//! `seq0`-derived molecule.
 //!
 //! ```text
-//! ref   seq0 ==A==|100        seq1 900|==B==
-//! adj   seq0:>:100(i)::seq1:<:900(i)::.
-//! =>    ==A==|==B==            Translocation { Interchromosomal, CoLinear }
+//! seq0   ==P==Q==|100 . . .            keep P Q up to boundary 100
+//! seq1        . . . 900|==R==S==       keep R S from boundary 900
+//! adj    seq0:>:100(i)::seq1:<:900(i)::.
+//! =>     ==P==Q==[R==S]==              [R S] is spliced in from seq1
+//!        Translocation { Interchromosomal, CoLinear }
 //! ```
 //!
-//! With matching orientations the fused piece is reverse-complemented, a
-//! fold-back.
+//! With matching orientations the segment brought over is reverse-complemented,
+//! a fold-back. Below, `[S' R']` is that same `seq1` segment, now inverted.
 //!
 //! ```text
-//! adj   seq0:>:100(i)::seq1:>:200(i)::.
-//! =>    ==A==| revcomp(seq1 piece)      Translocation { Interchromosomal, FoldBack }
+//! seq0   ==P==Q==|100 . . .            keep P Q up to boundary 100
+//! seq1        . . . |200 R==S==        matching orientation flips this piece
+//! adj    seq0:>:100(i)::seq1:>:200(i)::.
+//! =>     ==P==Q==[S'==R']==            [S' R'] is [R S] from seq1, reverse-complemented
+//!        Translocation { Interchromosomal, FoldBack }
 //! ```
 //!
 //! An intrachromosomal translocation is the balanced forward relocation of a

--- a/omics-variation/src/structural/adjacency.rs
+++ b/omics-variation/src/structural/adjacency.rs
@@ -93,7 +93,7 @@ enum Inner<N: Nucleotide> {
 /// A single novel junction between one or two oriented breakends.
 ///
 /// An adjacency is opaque. A paired adjacency is always held in canonical form,
-/// with its breakends ordered by [`Breakend::canonical_key`] and its insertion
+/// with its breakends ordered by their canonical key and its insertion
 /// carried in the reading frame of the canonical lower breakend, so that
 /// equality and later classification do not depend on the input order.
 ///
@@ -124,7 +124,7 @@ pub struct Adjacency<N: Nucleotide> {
 impl<N: Nucleotide + Complement> Adjacency<N> {
     /// Attempts to create a paired [`Adjacency`] in canonical form.
     ///
-    /// The two breakends are ordered by [`Breakend::canonical_key`]. When
+    /// The two breakends are ordered by their canonical key. When
     /// ordering swaps the supplied pair, the insertion is reverse-complemented
     /// into the reading frame of the canonical lower breakend. The identity
     /// join, meaning two breakends at the same locus with opposite orientations

--- a/omics-variation/src/structural/adjacency.rs
+++ b/omics-variation/src/structural/adjacency.rs
@@ -1,11 +1,28 @@
 //! Novel adjacencies between breakends.
 
+use std::fmt;
+use std::str::FromStr;
+
 use omics_molecule::compound::Complement;
 use omics_molecule::compound::Nucleotide;
+use omics_molecule::sequence;
 use omics_molecule::sequence::Sequence;
 use thiserror::Error;
 
+use crate::structural::breakend;
 use crate::structural::breakend::Breakend;
+
+/// The separator between an adjacency's breakend and insertion fields.
+///
+/// It is distinct from the breakend-internal separator so a whole breakend
+/// token never contains it, keeping the split unambiguous.
+const ADJACENCY_SEPARATOR: &str = "::";
+
+/// The token marking the open side of a single-ended adjacency.
+///
+/// It sits in the middle field. A paired breakend token is never this value,
+/// so the middle field alone disambiguates single-ended from paired.
+const OPEN_SIDE: &str = ".";
 
 /// An error related to constructing an [`Adjacency`].
 #[derive(Error, Debug, PartialEq, Eq)]
@@ -14,6 +31,26 @@ pub enum Error {
     /// an empty insertion, which encodes no change.
     #[error("adjacency is an identity join and encodes no change")]
     IdentityJoin,
+}
+
+/// A parse error related to an [`Adjacency`].
+#[derive(Error, Debug)]
+pub enum ParseError {
+    /// The adjacency did not split into exactly three `::`-separated fields.
+    #[error("invalid adjacency format: `{0}`")]
+    Format(String),
+
+    /// A breakend field failed to parse.
+    #[error(transparent)]
+    Breakend(#[from] breakend::ParseError),
+
+    /// The insertion sequence failed to parse.
+    #[error(transparent)]
+    Insertion(#[from] sequence::ParseError),
+
+    /// The paired adjacency could not be constructed.
+    #[error(transparent)]
+    Construct(#[from] Error),
 }
 
 /// The private inner representation of an [`Adjacency`].
@@ -57,6 +94,22 @@ enum Inner<N: Nucleotide> {
 ///
 /// `Hash` is intentionally not derived because `Sequence` does not implement
 /// it.
+///
+/// An adjacency serializes as three `::`-separated fields. A paired adjacency
+/// renders both breakends and its insertion, while a single-ended one renders
+/// its one breakend, a literal `.` marking the open side, and its insertion.
+///
+/// # Examples
+///
+/// ```
+/// use omics_molecule::polymer::dna;
+/// use omics_variation::structural::adjacency::Adjacency;
+///
+/// let rendered = "seq0:>:100(i)::seq1:<:200(i)::AT";
+/// let adjacency = rendered.parse::<Adjacency<dna::Nucleotide>>()?;
+/// assert_eq!(adjacency.to_string(), rendered);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Adjacency<N: Nucleotide> {
     /// The private, canonical inner representation.
@@ -185,6 +238,43 @@ impl<N: Nucleotide> Adjacency<N> {
     }
 }
 
+impl<N: Nucleotide> fmt::Display for Adjacency<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some((a, b, insertion)) = self.paired() {
+            write!(f, "{a}{ADJACENCY_SEPARATOR}{b}{ADJACENCY_SEPARATOR}{insertion}")
+        } else if let Some((breakend, insertion)) = self.single() {
+            write!(
+                f,
+                "{breakend}{ADJACENCY_SEPARATOR}{OPEN_SIDE}{ADJACENCY_SEPARATOR}{insertion}"
+            )
+        } else {
+            unreachable!("an adjacency is always paired or single")
+        }
+    }
+}
+
+impl<N: Nucleotide + Complement> FromStr for Adjacency<N> {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts = s.split(ADJACENCY_SEPARATOR).collect::<Vec<_>>();
+        let [first, middle, insertion] = parts.as_slice() else {
+            return Err(ParseError::Format(s.to_string()));
+        };
+
+        let insertion = insertion.parse::<Sequence<N>>()?;
+
+        if *middle == OPEN_SIDE {
+            let breakend = first.parse::<Breakend>()?;
+            Ok(Adjacency::new_single(breakend, insertion))
+        } else {
+            let a = first.parse::<Breakend>()?;
+            let b = middle.parse::<Breakend>()?;
+            Ok(Adjacency::try_new_paired(a, b, insertion)?)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use omics_coordinate::position::Number;
@@ -238,5 +328,74 @@ mod tests {
         let b = bnd("seq0", Orientation::HigherFlank, 100);
         let err = Adjacency::try_new_paired(a, b, seq(".")).unwrap_err();
         assert!(matches!(err, Error::IdentityJoin));
+    }
+
+    fn round_trip(adjacency: Adjacency<dna::Nucleotide>) {
+        let rendered = adjacency.to_string();
+        let parsed = rendered.parse::<Adjacency<dna::Nucleotide>>().unwrap();
+        assert_eq!(parsed, adjacency);
+        assert_eq!(parsed.to_string(), rendered);
+    }
+
+    #[test]
+    fn it_round_trips_a_paired_adjacency_with_an_insertion() {
+        let adjacency = Adjacency::try_new_paired(
+            bnd("seq0", Orientation::LowerFlank, 100),
+            bnd("seq1", Orientation::HigherFlank, 200),
+            seq("AT"),
+        )
+        .unwrap();
+        assert_eq!(adjacency.to_string(), "seq0:>:100(i)::seq1:<:200(i)::AT");
+        round_trip(adjacency);
+    }
+
+    #[test]
+    fn it_round_trips_a_paired_adjacency_with_an_empty_insertion() {
+        let adjacency = Adjacency::try_new_paired(
+            bnd("seq0", Orientation::LowerFlank, 100),
+            bnd("seq0", Orientation::HigherFlank, 200),
+            seq("."),
+        )
+        .unwrap();
+        assert_eq!(adjacency.to_string(), "seq0:>:100(i)::seq0:<:200(i)::.");
+        round_trip(adjacency);
+    }
+
+    #[test]
+    fn it_round_trips_a_single_ended_adjacency_with_an_insertion() {
+        let adjacency = Adjacency::new_single(bnd("seq0", Orientation::LowerFlank, 100), seq("AT"));
+        assert_eq!(adjacency.to_string(), "seq0:>:100(i)::.::AT");
+        round_trip(adjacency);
+    }
+
+    #[test]
+    fn it_round_trips_a_single_ended_adjacency_with_an_empty_insertion() {
+        let adjacency = Adjacency::new_single(bnd("seq0", Orientation::LowerFlank, 100), seq("."));
+        assert_eq!(adjacency.to_string(), "seq0:>:100(i)::.::.");
+        round_trip(adjacency);
+    }
+
+    #[test]
+    fn it_rejects_too_few_fields() {
+        let err = "seq0:>:100(i)::AT"
+            .parse::<Adjacency<dna::Nucleotide>>()
+            .unwrap_err();
+        assert!(matches!(err, ParseError::Format(_)));
+    }
+
+    #[test]
+    fn it_rejects_too_many_fields() {
+        let err = "seq0:>:100(i)::seq1:<:200(i)::AT::extra"
+            .parse::<Adjacency<dna::Nucleotide>>()
+            .unwrap_err();
+        assert!(matches!(err, ParseError::Format(_)));
+    }
+
+    #[test]
+    fn it_rejects_a_bad_breakend() {
+        let err = "bad::seq1:<:200(i)::AT"
+            .parse::<Adjacency<dna::Nucleotide>>()
+            .unwrap_err();
+        assert!(matches!(err, ParseError::Breakend(_)));
     }
 }

--- a/omics-variation/src/structural/adjacency.rs
+++ b/omics-variation/src/structural/adjacency.rs
@@ -65,10 +65,7 @@ pub enum ParseError {
 /// so that equality and later classification do not depend on the input order.
 /// A value of this type can only be built through [`PairedAdjacency::try_new`],
 /// so it always upholds those invariants.
-///
-/// `Hash` is intentionally not derived because `Sequence` does not implement
-/// it.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PairedAdjacency<N: Nucleotide> {
     /// The canonical lower-locus breakend.
     a: Breakend,
@@ -207,10 +204,7 @@ impl<N: Nucleotide> fmt::Display for PairedAdjacency<N> {
 ///
 /// One side is a known breakend and the other is open, so the adjacency carries
 /// a single locus and the non-templated insertion at its open side.
-///
-/// `Hash` is intentionally not derived because `Sequence` does not implement
-/// it.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SingleAdjacency<N: Nucleotide> {
     /// The single known breakend.
     breakend: Breakend,
@@ -296,9 +290,6 @@ impl<N: Nucleotide> fmt::Display for SingleAdjacency<N> {
 /// unassembled sequence. Each variant wraps a strong type that owns its
 /// invariants, so a paired junction is always canonical.
 ///
-/// `Hash` is intentionally not derived because `Sequence` does not implement
-/// it.
-///
 /// An adjacency serializes as three `::`-separated fields. A paired adjacency
 /// renders both breakends and its insertion, while a single-ended one renders
 /// its one breakend, a literal `.` marking the open side, and its insertion.
@@ -314,7 +305,7 @@ impl<N: Nucleotide> fmt::Display for SingleAdjacency<N> {
 /// assert_eq!(adjacency.to_string(), rendered);
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Adjacency<N: Nucleotide> {
     /// Two loci joined, with optional non-templated bases between them.
     Paired(PairedAdjacency<N>),

--- a/omics-variation/src/structural/adjacency.rs
+++ b/omics-variation/src/structural/adjacency.rs
@@ -1,0 +1,242 @@
+//! Novel adjacencies between breakends.
+
+use omics_molecule::compound::Complement;
+use omics_molecule::compound::Nucleotide;
+use omics_molecule::sequence::Sequence;
+use thiserror::Error;
+
+use crate::structural::breakend::Breakend;
+
+/// An error related to constructing an [`Adjacency`].
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum Error {
+    /// The two breakends sit at the same locus with opposite orientations and
+    /// an empty insertion, which encodes no change.
+    #[error("adjacency is an identity join and encodes no change")]
+    IdentityJoin,
+}
+
+/// The private inner representation of an [`Adjacency`].
+///
+/// Keeping this enum private makes [`Adjacency`] opaque, so callers cannot
+/// build a non-canonical or identity adjacency that would break classification.
+/// Adjacencies are built only through [`Adjacency::try_new_paired`] and
+/// [`Adjacency::new_single`], and are read back through
+/// [`Adjacency::paired`] and [`Adjacency::single`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Inner<N: Nucleotide> {
+    /// Two loci joined, with optional non-templated bases between them.
+    Paired {
+        /// The canonical lower-locus breakend.
+        a: Breakend,
+
+        /// The canonical higher-locus breakend.
+        b: Breakend,
+
+        /// The non-templated insertion, in the reading frame of `a`.
+        insertion: Sequence<N>,
+    },
+
+    /// One locus joined to novel or unassembled sequence, open on the other
+    /// side.
+    Single {
+        /// The single known breakend.
+        breakend: Breakend,
+
+        /// The non-templated insertion at the open side.
+        insertion: Sequence<N>,
+    },
+}
+
+/// A single novel junction between one or two oriented breakends.
+///
+/// An adjacency is opaque. A paired adjacency is always held in canonical form,
+/// with its breakends ordered by [`Breakend::canonical_key`] and its insertion
+/// carried in the reading frame of the canonical lower breakend, so that
+/// equality and later classification do not depend on the input order.
+///
+/// `Hash` is intentionally not derived because `Sequence` does not implement
+/// it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Adjacency<N: Nucleotide> {
+    /// The private, canonical inner representation.
+    inner: Inner<N>,
+}
+
+impl<N: Nucleotide + Complement> Adjacency<N> {
+    /// Attempts to create a paired [`Adjacency`] in canonical form.
+    ///
+    /// The two breakends are ordered by [`Breakend::canonical_key`]. When
+    /// ordering swaps the supplied pair, the insertion is reverse-complemented
+    /// into the reading frame of the canonical lower breakend. The identity
+    /// join, meaning two breakends at the same locus with opposite orientations
+    /// and an empty insertion, is rejected because it encodes no change.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use omics_molecule::polymer::dna;
+    /// use omics_variation::structural::adjacency::Adjacency;
+    /// use omics_variation::structural::breakend::Breakend;
+    /// use omics_variation::structural::orientation::Orientation;
+    ///
+    /// let a = Breakend::try_new("seq0", Orientation::LowerFlank, 100)?;
+    /// let b = Breakend::try_new("seq0", Orientation::HigherFlank, 200)?;
+    /// let adjacency = Adjacency::<dna::Nucleotide>::try_new_paired(a, b, ".".parse()?)?;
+    /// assert!(adjacency.paired().is_some());
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn try_new_paired(x: Breakend, y: Breakend, insertion: Sequence<N>) -> Result<Self, Error> {
+        let (a, b, insertion) = if x.canonical_key() <= y.canonical_key() {
+            (x, y, insertion)
+        } else {
+            (y, x, insertion.reverse_complement())
+        };
+
+        let same_locus = a.contig() == b.contig() && a.position().get() == b.position().get();
+        let opposite = a.orientation().is_opposite(b.orientation());
+        if same_locus && opposite && insertion.is_empty() {
+            return Err(Error::IdentityJoin);
+        }
+
+        Ok(Self {
+            inner: Inner::Paired { a, b, insertion },
+        })
+    }
+}
+
+impl<N: Nucleotide> Adjacency<N> {
+    /// Creates a single-ended [`Adjacency`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use omics_molecule::polymer::dna;
+    /// use omics_variation::structural::adjacency::Adjacency;
+    /// use omics_variation::structural::breakend::Breakend;
+    /// use omics_variation::structural::orientation::Orientation;
+    ///
+    /// let breakend = Breakend::try_new("seq0", Orientation::LowerFlank, 100)?;
+    /// let adjacency = Adjacency::<dna::Nucleotide>::new_single(breakend, "AT".parse()?);
+    /// assert!(adjacency.single().is_some());
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn new_single(breakend: Breakend, insertion: Sequence<N>) -> Self {
+        Self {
+            inner: Inner::Single {
+                breakend,
+                insertion,
+            },
+        }
+    }
+
+    /// Gets the two canonical breakends and insertion of a paired adjacency, or
+    /// `None` for a single-ended one.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use omics_molecule::polymer::dna;
+    /// use omics_variation::structural::adjacency::Adjacency;
+    /// use omics_variation::structural::breakend::Breakend;
+    /// use omics_variation::structural::orientation::Orientation;
+    ///
+    /// let a = Breakend::try_new("seq0", Orientation::LowerFlank, 100)?;
+    /// let b = Breakend::try_new("seq0", Orientation::HigherFlank, 200)?;
+    /// let adjacency = Adjacency::<dna::Nucleotide>::try_new_paired(a, b, ".".parse()?)?;
+    /// let (lower, higher, _) = adjacency.paired().expect("a paired adjacency");
+    /// assert_eq!(lower.position().get(), 100);
+    /// assert_eq!(higher.position().get(), 200);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn paired(&self) -> Option<(&Breakend, &Breakend, &Sequence<N>)> {
+        match &self.inner {
+            Inner::Paired { a, b, insertion } => Some((a, b, insertion)),
+            Inner::Single { .. } => None,
+        }
+    }
+
+    /// Gets the breakend and insertion of a single-ended adjacency, or `None`
+    /// for a paired one.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use omics_molecule::polymer::dna;
+    /// use omics_variation::structural::adjacency::Adjacency;
+    /// use omics_variation::structural::breakend::Breakend;
+    /// use omics_variation::structural::orientation::Orientation;
+    ///
+    /// let breakend = Breakend::try_new("seq0", Orientation::LowerFlank, 100)?;
+    /// let adjacency = Adjacency::<dna::Nucleotide>::new_single(breakend, "AT".parse()?);
+    /// let (breakend, insertion) = adjacency.single().expect("a single adjacency");
+    /// assert_eq!(breakend.position().get(), 100);
+    /// assert_eq!(insertion.to_string(), "AT");
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn single(&self) -> Option<(&Breakend, &Sequence<N>)> {
+        match &self.inner {
+            Inner::Single {
+                breakend,
+                insertion,
+            } => Some((breakend, insertion)),
+            Inner::Paired { .. } => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use omics_coordinate::position::Number;
+    use omics_molecule::polymer::dna;
+
+    use super::*;
+    use crate::structural::orientation::Orientation;
+
+    fn bnd(contig: &str, orientation: Orientation, position: Number) -> Breakend {
+        Breakend::try_new(contig, orientation, position).unwrap()
+    }
+
+    fn seq(value: &str) -> Sequence<dna::Nucleotide> {
+        value.parse().unwrap()
+    }
+
+    #[test]
+    fn it_canonicalizes_supplied_order() {
+        let lo = bnd("seq0", Orientation::LowerFlank, 100);
+        let hi = bnd("seq0", Orientation::HigherFlank, 200);
+
+        let forward = Adjacency::try_new_paired(lo.clone(), hi.clone(), seq(".")).unwrap();
+        let backward = Adjacency::try_new_paired(hi, lo, seq(".")).unwrap();
+        assert_eq!(forward, backward);
+    }
+
+    #[test]
+    fn it_reverse_complements_the_insertion_on_swap() {
+        let lo = bnd("seq0", Orientation::LowerFlank, 100);
+        let hi = bnd("seq0", Orientation::HigherFlank, 200);
+
+        // Supplied high-to-low, so the insertion is reverse-complemented into
+        // the canonical low-to-high frame. `AAAC` reverse-complements to `GTTT`.
+        let adjacency = Adjacency::try_new_paired(hi, lo, seq("AAAC")).unwrap();
+        let (_, _, insertion) = adjacency.paired().expect("a paired adjacency");
+        assert_eq!(insertion.to_string(), "GTTT");
+    }
+
+    #[test]
+    fn it_exposes_a_single_adjacency_through_the_accessor() {
+        let breakend = bnd("seq0", Orientation::LowerFlank, 100);
+        let adjacency = Adjacency::new_single(breakend, seq("AT"));
+        assert!(adjacency.paired().is_none());
+        let (_, insertion) = adjacency.single().expect("a single adjacency");
+        assert_eq!(insertion.to_string(), "AT");
+    }
+
+    #[test]
+    fn it_rejects_the_identity_join() {
+        let a = bnd("seq0", Orientation::LowerFlank, 100);
+        let b = bnd("seq0", Orientation::HigherFlank, 100);
+        let err = Adjacency::try_new_paired(a, b, seq(".")).unwrap_err();
+        assert!(matches!(err, Error::IdentityJoin));
+    }
+}

--- a/omics-variation/src/structural/adjacency.rs
+++ b/omics-variation/src/structural/adjacency.rs
@@ -241,7 +241,10 @@ impl<N: Nucleotide> Adjacency<N> {
 impl<N: Nucleotide> fmt::Display for Adjacency<N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some((a, b, insertion)) = self.paired() {
-            write!(f, "{a}{ADJACENCY_SEPARATOR}{b}{ADJACENCY_SEPARATOR}{insertion}")
+            write!(
+                f,
+                "{a}{ADJACENCY_SEPARATOR}{b}{ADJACENCY_SEPARATOR}{insertion}"
+            )
         } else if let Some((breakend, insertion)) = self.single() {
             write!(
                 f,

--- a/omics-variation/src/structural/adjacency.rs
+++ b/omics-variation/src/structural/adjacency.rs
@@ -463,6 +463,25 @@ mod tests {
     }
 
     #[test]
+    fn it_accepts_a_same_locus_insertion() {
+        // Same locus and opposite orientations, but with inserted bases, is a
+        // valid large insertion rather than an identity join. The empty
+        // insertion is the only thing that distinguishes the two.
+        let adjacency = Adjacency::try_new_paired(
+            bnd("seq0", Orientation::LowerFlank, 100),
+            bnd("seq0", Orientation::HigherFlank, 100),
+            seq("ACGT"),
+        )
+        .unwrap();
+        let Adjacency::Paired(paired) = adjacency else {
+            panic!("expected a paired adjacency");
+        };
+        assert_eq!(paired.a().position().get(), 100);
+        assert_eq!(paired.b().position().get(), 100);
+        assert_eq!(paired.insertion().to_string(), "ACGT");
+    }
+
+    #[test]
     fn it_rejects_a_self_junction() {
         // Fully identical breakends, meaning the same contig, position, and
         // orientation, join a breakend to itself and are rejected, both with an

--- a/omics-variation/src/structural/adjacency.rs
+++ b/omics-variation/src/structural/adjacency.rs
@@ -392,6 +392,16 @@ mod tests {
     }
 
     #[test]
+    fn it_rejects_an_identity_join_from_a_string() {
+        // Same locus, opposite orientations, and an empty insertion, so the
+        // parsed paired join encodes no change and must be rejected.
+        let err = "seq0:>:100(i)::seq0:<:100(i)::."
+            .parse::<Adjacency<dna::Nucleotide>>()
+            .unwrap_err();
+        assert!(matches!(err, ParseError::Construct(Error::IdentityJoin)));
+    }
+
+    #[test]
     fn it_rejects_a_bad_breakend() {
         let err = "bad::seq1:<:200(i)::AT"
             .parse::<Adjacency<dna::Nucleotide>>()

--- a/omics-variation/src/structural/adjacency.rs
+++ b/omics-variation/src/structural/adjacency.rs
@@ -83,15 +83,17 @@ pub struct PairedAdjacency<N: Nucleotide> {
 impl<N: Nucleotide + Complement> PairedAdjacency<N> {
     /// Attempts to create a [`PairedAdjacency`] in canonical form.
     ///
-    /// The two breakends are ordered by their canonical key. The `insertion` is
-    /// supplied as it reads across the junction from the first breakend `x`
-    /// toward the second breakend `y`. Canonical form instead reads from the
-    /// lower breakend to the higher one, so when ordering swaps the supplied
-    /// pair the insertion is reverse-complemented into that frame. The identity
-    /// join, meaning two breakends at the same locus with opposite orientations
-    /// and an empty insertion, is rejected because it encodes no change. Two
-    /// fully identical breakends are rejected because they join a breakend to
-    /// itself.
+    /// The two breakends are ordered by their canonical key, which sorts by
+    /// contig, then interbase position, then orientation. The `insertion` is
+    /// supplied as it reads across the junction from the first argument `x`
+    /// toward the second argument `y`. If `x` already sorts at or before `y`,
+    /// both are kept as given. If `x` sorts after `y`, the pair is swapped into
+    /// canonical order and the insertion is reverse-complemented so that it
+    /// still reads from the canonical lower breakend toward the higher one. The
+    /// identity join, meaning two breakends at the same locus with opposite
+    /// orientations and an empty insertion, is rejected because it encodes no
+    /// change. Two fully identical breakends are rejected because they join a
+    /// breakend to itself.
     ///
     /// # Examples
     ///

--- a/omics-variation/src/structural/adjacency.rs
+++ b/omics-variation/src/structural/adjacency.rs
@@ -24,7 +24,7 @@ const ADJACENCY_SEPARATOR: &str = "::";
 /// so the middle field alone disambiguates single-ended from paired.
 const OPEN_SIDE: &str = ".";
 
-/// An error related to constructing an [`Adjacency`].
+/// An error related to constructing a [`PairedAdjacency`].
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum Error {
     /// The two breakends sit at the same locus with opposite orientations and
@@ -58,93 +58,56 @@ pub enum ParseError {
     Construct(#[from] Error),
 }
 
-/// The private inner representation of an [`Adjacency`].
+/// A junction joining two oriented breakends, held in canonical form.
 ///
-/// Keeping this enum private makes [`Adjacency`] opaque, so callers cannot
-/// build a non-canonical or identity adjacency that would break classification.
-/// Adjacencies are built only through [`Adjacency::try_new_paired`] and
-/// [`Adjacency::new_single`], and are read back through
-/// [`Adjacency::paired`] and [`Adjacency::single`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum Inner<N: Nucleotide> {
-    /// Two loci joined, with optional non-templated bases between them.
-    Paired {
-        /// The canonical lower-locus breakend.
-        a: Breakend,
-
-        /// The canonical higher-locus breakend.
-        b: Breakend,
-
-        /// The non-templated insertion, in the reading frame of `a`.
-        insertion: Sequence<N>,
-    },
-
-    /// One locus joined to novel or unassembled sequence, open on the other
-    /// side.
-    Single {
-        /// The single known breakend.
-        breakend: Breakend,
-
-        /// The non-templated insertion at the open side.
-        insertion: Sequence<N>,
-    },
-}
-
-/// A single novel junction between one or two oriented breakends.
-///
-/// An adjacency is opaque. A paired adjacency is always held in canonical form,
-/// with its breakends ordered by their canonical key and its insertion
-/// carried in the reading frame of the canonical lower breakend, so that
-/// equality and later classification do not depend on the input order.
+/// The two breakends are ordered by their canonical key, and the non-templated
+/// insertion is carried in the reading frame of the canonical lower breakend,
+/// so that equality and later classification do not depend on the input order.
+/// A value of this type can only be built through [`PairedAdjacency::try_new`],
+/// so it always upholds those invariants.
 ///
 /// `Hash` is intentionally not derived because `Sequence` does not implement
 /// it.
-///
-/// An adjacency serializes as three `::`-separated fields. A paired adjacency
-/// renders both breakends and its insertion, while a single-ended one renders
-/// its one breakend, a literal `.` marking the open side, and its insertion.
-///
-/// # Examples
-///
-/// ```
-/// use omics_molecule::polymer::dna;
-/// use omics_variation::structural::adjacency::Adjacency;
-///
-/// let rendered = "seq0:>:100(i)::seq1:<:200(i)::AT";
-/// let adjacency = rendered.parse::<Adjacency<dna::Nucleotide>>()?;
-/// assert_eq!(adjacency.to_string(), rendered);
-/// # Ok::<(), Box<dyn std::error::Error>>(())
-/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Adjacency<N: Nucleotide> {
-    /// The private, canonical inner representation.
-    inner: Inner<N>,
+pub struct PairedAdjacency<N: Nucleotide> {
+    /// The canonical lower-locus breakend.
+    a: Breakend,
+
+    /// The canonical higher-locus breakend.
+    b: Breakend,
+
+    /// The non-templated insertion, in the reading frame of `a`.
+    insertion: Sequence<N>,
 }
 
-impl<N: Nucleotide + Complement> Adjacency<N> {
-    /// Attempts to create a paired [`Adjacency`] in canonical form.
+impl<N: Nucleotide + Complement> PairedAdjacency<N> {
+    /// Attempts to create a [`PairedAdjacency`] in canonical form.
     ///
-    /// The two breakends are ordered by their canonical key. When
-    /// ordering swaps the supplied pair, the insertion is reverse-complemented
-    /// into the reading frame of the canonical lower breakend. The identity
+    /// The two breakends are ordered by their canonical key. The `insertion` is
+    /// supplied as it reads across the junction from the first breakend `x`
+    /// toward the second breakend `y`. Canonical form instead reads from the
+    /// lower breakend to the higher one, so when ordering swaps the supplied
+    /// pair the insertion is reverse-complemented into that frame. The identity
     /// join, meaning two breakends at the same locus with opposite orientations
-    /// and an empty insertion, is rejected because it encodes no change.
+    /// and an empty insertion, is rejected because it encodes no change. Two
+    /// fully identical breakends are rejected because they join a breakend to
+    /// itself.
     ///
     /// # Examples
     ///
     /// ```
     /// use omics_molecule::polymer::dna;
-    /// use omics_variation::structural::adjacency::Adjacency;
+    /// use omics_variation::structural::adjacency::PairedAdjacency;
     /// use omics_variation::structural::breakend::Breakend;
     /// use omics_variation::structural::orientation::Orientation;
     ///
     /// let a = Breakend::try_new("seq0", Orientation::LowerFlank, 100)?;
     /// let b = Breakend::try_new("seq0", Orientation::HigherFlank, 200)?;
-    /// let adjacency = Adjacency::<dna::Nucleotide>::try_new_paired(a, b, ".".parse()?)?;
-    /// assert!(adjacency.paired().is_some());
+    /// let paired = PairedAdjacency::<dna::Nucleotide>::try_new(a, b, ".".parse()?)?;
+    /// assert_eq!(paired.a().position().get(), 100);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn try_new_paired(x: Breakend, y: Breakend, insertion: Sequence<N>) -> Result<Self, Error> {
+    pub fn try_new(x: Breakend, y: Breakend, insertion: Sequence<N>) -> Result<Self, Error> {
         let (a, b, insertion) = if x.canonical_key() <= y.canonical_key() {
             (x, y, insertion)
         } else {
@@ -165,39 +128,204 @@ impl<N: Nucleotide + Complement> Adjacency<N> {
             return Err(Error::IdentityJoin);
         }
 
-        Ok(Self {
-            inner: Inner::Paired { a, b, insertion },
-        })
+        Ok(Self { a, b, insertion })
     }
 }
 
-impl<N: Nucleotide> Adjacency<N> {
-    /// Creates a single-ended [`Adjacency`].
+impl<N: Nucleotide> PairedAdjacency<N> {
+    /// Gets the canonical lower-locus breakend.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use omics_molecule::polymer::dna;
+    /// # use omics_variation::structural::adjacency::PairedAdjacency;
+    /// # use omics_variation::structural::breakend::Breakend;
+    /// # use omics_variation::structural::orientation::Orientation;
+    /// let a = Breakend::try_new("seq0", Orientation::LowerFlank, 100)?;
+    /// let b = Breakend::try_new("seq0", Orientation::HigherFlank, 200)?;
+    /// let paired = PairedAdjacency::<dna::Nucleotide>::try_new(a, b, ".".parse()?)?;
+    /// assert_eq!(paired.a().position().get(), 100);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn a(&self) -> &Breakend {
+        &self.a
+    }
+
+    /// Gets the canonical higher-locus breakend.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use omics_molecule::polymer::dna;
+    /// # use omics_variation::structural::adjacency::PairedAdjacency;
+    /// # use omics_variation::structural::breakend::Breakend;
+    /// # use omics_variation::structural::orientation::Orientation;
+    /// let a = Breakend::try_new("seq0", Orientation::LowerFlank, 100)?;
+    /// let b = Breakend::try_new("seq0", Orientation::HigherFlank, 200)?;
+    /// let paired = PairedAdjacency::<dna::Nucleotide>::try_new(a, b, ".".parse()?)?;
+    /// assert_eq!(paired.b().position().get(), 200);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn b(&self) -> &Breakend {
+        &self.b
+    }
+
+    /// Gets the non-templated insertion, in the reading frame of `a`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use omics_molecule::polymer::dna;
+    /// # use omics_variation::structural::adjacency::PairedAdjacency;
+    /// # use omics_variation::structural::breakend::Breakend;
+    /// # use omics_variation::structural::orientation::Orientation;
+    /// let a = Breakend::try_new("seq0", Orientation::LowerFlank, 100)?;
+    /// let b = Breakend::try_new("seq1", Orientation::HigherFlank, 200)?;
+    /// let paired = PairedAdjacency::<dna::Nucleotide>::try_new(a, b, "AT".parse()?)?;
+    /// assert_eq!(paired.insertion().to_string(), "AT");
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn insertion(&self) -> &Sequence<N> {
+        &self.insertion
+    }
+}
+
+impl<N: Nucleotide> fmt::Display for PairedAdjacency<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}{ADJACENCY_SEPARATOR}{}{ADJACENCY_SEPARATOR}{}",
+            self.a, self.b, self.insertion
+        )
+    }
+}
+
+/// A junction joining one breakend to novel or unassembled sequence.
+///
+/// One side is a known breakend and the other is open, so the adjacency carries
+/// a single locus and the non-templated insertion at its open side.
+///
+/// `Hash` is intentionally not derived because `Sequence` does not implement
+/// it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SingleAdjacency<N: Nucleotide> {
+    /// The single known breakend.
+    breakend: Breakend,
+
+    /// The non-templated insertion at the open side.
+    insertion: Sequence<N>,
+}
+
+impl<N: Nucleotide> SingleAdjacency<N> {
+    /// Creates a [`SingleAdjacency`].
     ///
     /// # Examples
     ///
     /// ```
     /// use omics_molecule::polymer::dna;
-    /// use omics_variation::structural::adjacency::Adjacency;
+    /// use omics_variation::structural::adjacency::SingleAdjacency;
     /// use omics_variation::structural::breakend::Breakend;
     /// use omics_variation::structural::orientation::Orientation;
     ///
     /// let breakend = Breakend::try_new("seq0", Orientation::LowerFlank, 100)?;
-    /// let adjacency = Adjacency::<dna::Nucleotide>::new_single(breakend, "AT".parse()?);
-    /// assert!(adjacency.single().is_some());
+    /// let single = SingleAdjacency::<dna::Nucleotide>::new(breakend, "AT".parse()?);
+    /// assert_eq!(single.insertion().to_string(), "AT");
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn new_single(breakend: Breakend, insertion: Sequence<N>) -> Self {
+    pub fn new(breakend: Breakend, insertion: Sequence<N>) -> Self {
         Self {
-            inner: Inner::Single {
-                breakend,
-                insertion,
-            },
+            breakend,
+            insertion,
         }
     }
 
-    /// Gets the two canonical breakends and insertion of a paired adjacency, or
-    /// `None` for a single-ended one.
+    /// Gets the single known breakend.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use omics_molecule::polymer::dna;
+    /// # use omics_variation::structural::adjacency::SingleAdjacency;
+    /// # use omics_variation::structural::breakend::Breakend;
+    /// # use omics_variation::structural::orientation::Orientation;
+    /// let breakend = Breakend::try_new("seq0", Orientation::LowerFlank, 100)?;
+    /// let single = SingleAdjacency::<dna::Nucleotide>::new(breakend, "AT".parse()?);
+    /// assert_eq!(single.breakend().position().get(), 100);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn breakend(&self) -> &Breakend {
+        &self.breakend
+    }
+
+    /// Gets the non-templated insertion at the open side.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use omics_molecule::polymer::dna;
+    /// # use omics_variation::structural::adjacency::SingleAdjacency;
+    /// # use omics_variation::structural::breakend::Breakend;
+    /// # use omics_variation::structural::orientation::Orientation;
+    /// let breakend = Breakend::try_new("seq0", Orientation::LowerFlank, 100)?;
+    /// let single = SingleAdjacency::<dna::Nucleotide>::new(breakend, "AT".parse()?);
+    /// assert_eq!(single.insertion().to_string(), "AT");
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn insertion(&self) -> &Sequence<N> {
+        &self.insertion
+    }
+}
+
+impl<N: Nucleotide> fmt::Display for SingleAdjacency<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}{ADJACENCY_SEPARATOR}{OPEN_SIDE}{ADJACENCY_SEPARATOR}{}",
+            self.breakend, self.insertion
+        )
+    }
+}
+
+/// A single novel junction between one or two oriented breakends.
+///
+/// A [`Paired`](Adjacency::Paired) junction joins two known loci, while a
+/// [`Single`](Adjacency::Single) junction joins one known locus to novel or
+/// unassembled sequence. Each variant wraps a strong type that owns its
+/// invariants, so a paired junction is always canonical.
+///
+/// `Hash` is intentionally not derived because `Sequence` does not implement
+/// it.
+///
+/// An adjacency serializes as three `::`-separated fields. A paired adjacency
+/// renders both breakends and its insertion, while a single-ended one renders
+/// its one breakend, a literal `.` marking the open side, and its insertion.
+///
+/// # Examples
+///
+/// ```
+/// use omics_molecule::polymer::dna;
+/// use omics_variation::structural::adjacency::Adjacency;
+///
+/// let rendered = "seq0:>:100(i)::seq1:<:200(i)::AT";
+/// let adjacency = rendered.parse::<Adjacency<dna::Nucleotide>>()?;
+/// assert_eq!(adjacency.to_string(), rendered);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Adjacency<N: Nucleotide> {
+    /// Two loci joined, with optional non-templated bases between them.
+    Paired(PairedAdjacency<N>),
+
+    /// One locus joined to novel or unassembled sequence, open on the other
+    /// side.
+    Single(SingleAdjacency<N>),
+}
+
+impl<N: Nucleotide + Complement> Adjacency<N> {
+    /// Attempts to create a paired [`Adjacency`] in canonical form.
+    ///
+    /// This is a convenience wrapper over [`PairedAdjacency::try_new`].
     ///
     /// # Examples
     ///
@@ -210,20 +338,20 @@ impl<N: Nucleotide> Adjacency<N> {
     /// let a = Breakend::try_new("seq0", Orientation::LowerFlank, 100)?;
     /// let b = Breakend::try_new("seq0", Orientation::HigherFlank, 200)?;
     /// let adjacency = Adjacency::<dna::Nucleotide>::try_new_paired(a, b, ".".parse()?)?;
-    /// let (lower, higher, _) = adjacency.paired().expect("a paired adjacency");
-    /// assert_eq!(lower.position().get(), 100);
-    /// assert_eq!(higher.position().get(), 200);
+    /// assert!(matches!(adjacency, Adjacency::Paired(_)));
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn paired(&self) -> Option<(&Breakend, &Breakend, &Sequence<N>)> {
-        match &self.inner {
-            Inner::Paired { a, b, insertion } => Some((a, b, insertion)),
-            Inner::Single { .. } => None,
-        }
+    pub fn try_new_paired(x: Breakend, y: Breakend, insertion: Sequence<N>) -> Result<Self, Error> {
+        Ok(Adjacency::Paired(PairedAdjacency::try_new(
+            x, y, insertion,
+        )?))
     }
+}
 
-    /// Gets the breakend and insertion of a single-ended adjacency, or `None`
-    /// for a paired one.
+impl<N: Nucleotide> Adjacency<N> {
+    /// Creates a single-ended [`Adjacency`].
+    ///
+    /// This is a convenience wrapper over [`SingleAdjacency::new`].
     ///
     /// # Examples
     ///
@@ -235,36 +363,19 @@ impl<N: Nucleotide> Adjacency<N> {
     ///
     /// let breakend = Breakend::try_new("seq0", Orientation::LowerFlank, 100)?;
     /// let adjacency = Adjacency::<dna::Nucleotide>::new_single(breakend, "AT".parse()?);
-    /// let (breakend, insertion) = adjacency.single().expect("a single adjacency");
-    /// assert_eq!(breakend.position().get(), 100);
-    /// assert_eq!(insertion.to_string(), "AT");
+    /// assert!(matches!(adjacency, Adjacency::Single(_)));
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn single(&self) -> Option<(&Breakend, &Sequence<N>)> {
-        match &self.inner {
-            Inner::Single {
-                breakend,
-                insertion,
-            } => Some((breakend, insertion)),
-            Inner::Paired { .. } => None,
-        }
+    pub fn new_single(breakend: Breakend, insertion: Sequence<N>) -> Self {
+        Adjacency::Single(SingleAdjacency::new(breakend, insertion))
     }
 }
 
 impl<N: Nucleotide> fmt::Display for Adjacency<N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some((a, b, insertion)) = self.paired() {
-            write!(
-                f,
-                "{a}{ADJACENCY_SEPARATOR}{b}{ADJACENCY_SEPARATOR}{insertion}"
-            )
-        } else if let Some((breakend, insertion)) = self.single() {
-            write!(
-                f,
-                "{breakend}{ADJACENCY_SEPARATOR}{OPEN_SIDE}{ADJACENCY_SEPARATOR}{insertion}"
-            )
-        } else {
-            unreachable!("an adjacency is always paired or single")
+        match self {
+            Adjacency::Paired(paired) => write!(f, "{paired}"),
+            Adjacency::Single(single) => write!(f, "{single}"),
         }
     }
 }
@@ -325,17 +436,20 @@ mod tests {
         // Supplied high-to-low, so the insertion is reverse-complemented into
         // the canonical low-to-high frame. `AAAC` reverse-complements to `GTTT`.
         let adjacency = Adjacency::try_new_paired(hi, lo, seq("AAAC")).unwrap();
-        let (_, _, insertion) = adjacency.paired().expect("a paired adjacency");
-        assert_eq!(insertion.to_string(), "GTTT");
+        let Adjacency::Paired(paired) = adjacency else {
+            panic!("expected a paired adjacency");
+        };
+        assert_eq!(paired.insertion().to_string(), "GTTT");
     }
 
     #[test]
-    fn it_exposes_a_single_adjacency_through_the_accessor() {
+    fn it_builds_a_single_adjacency() {
         let breakend = bnd("seq0", Orientation::LowerFlank, 100);
         let adjacency = Adjacency::new_single(breakend, seq("AT"));
-        assert!(adjacency.paired().is_none());
-        let (_, insertion) = adjacency.single().expect("a single adjacency");
-        assert_eq!(insertion.to_string(), "AT");
+        let Adjacency::Single(single) = adjacency else {
+            panic!("expected a single adjacency");
+        };
+        assert_eq!(single.insertion().to_string(), "AT");
     }
 
     #[test]

--- a/omics-variation/src/structural/adjacency.rs
+++ b/omics-variation/src/structural/adjacency.rs
@@ -31,6 +31,11 @@ pub enum Error {
     /// an empty insertion, which encodes no change.
     #[error("adjacency is an identity join and encodes no change")]
     IdentityJoin,
+
+    /// The two breakends are fully identical, meaning the same contig,
+    /// position, and orientation, so the adjacency joins a breakend to itself.
+    #[error("adjacency cannot join a breakend to itself")]
+    SelfJunction,
 }
 
 /// A parse error related to an [`Adjacency`].
@@ -147,6 +152,14 @@ impl<N: Nucleotide + Complement> Adjacency<N> {
         };
 
         let same_locus = a.contig() == b.contig() && a.position().get() == b.position().get();
+
+        // Reject a breakend joined to itself. Fully identical breakends, meaning
+        // the same contig, position, and orientation, encode a meaningless
+        // zero-length self-loop that would otherwise misclassify downstream.
+        if same_locus && a.orientation() == b.orientation() {
+            return Err(Error::SelfJunction);
+        }
+
         let opposite = a.orientation().is_opposite(b.orientation());
         if same_locus && opposite && insertion.is_empty() {
             return Err(Error::IdentityJoin);
@@ -331,6 +344,28 @@ mod tests {
         let b = bnd("seq0", Orientation::HigherFlank, 100);
         let err = Adjacency::try_new_paired(a, b, seq(".")).unwrap_err();
         assert!(matches!(err, Error::IdentityJoin));
+    }
+
+    #[test]
+    fn it_rejects_a_self_junction() {
+        // Fully identical breakends, meaning the same contig, position, and
+        // orientation, join a breakend to itself and are rejected, both with an
+        // empty and with a non-empty insertion.
+        let empty = Adjacency::try_new_paired(
+            bnd("seq0", Orientation::LowerFlank, 100),
+            bnd("seq0", Orientation::LowerFlank, 100),
+            seq("."),
+        )
+        .unwrap_err();
+        assert!(matches!(empty, Error::SelfJunction));
+
+        let inserted = Adjacency::try_new_paired(
+            bnd("seq0", Orientation::HigherFlank, 100),
+            bnd("seq0", Orientation::HigherFlank, 100),
+            seq("AAAC"),
+        )
+        .unwrap_err();
+        assert!(matches!(inserted, Error::SelfJunction));
     }
 
     fn round_trip(adjacency: Adjacency<dna::Nucleotide>) {

--- a/omics-variation/src/structural/breakend.rs
+++ b/omics-variation/src/structural/breakend.rs
@@ -45,7 +45,10 @@ pub enum ParseError {
 ///
 /// A breakend mirrors a coordinate's fields, except that the strand slot is
 /// replaced by an [`Orientation`]. A breakend has no meaningful biological
-/// strand, so it does not carry one.
+/// strand, so it does not carry one, and its [`Orientation`] names the retained
+/// flank by reference coordinate rather than by strand. See the [module
+/// documentation](crate::structural) for why read direction lives on the
+/// adjacency pair rather than on a breakend.
 ///
 /// `Hash` is intentionally not derived because `Position<Interbase>` does not
 /// implement it.

--- a/omics-variation/src/structural/breakend.rs
+++ b/omics-variation/src/structural/breakend.rs
@@ -49,10 +49,7 @@ pub enum ParseError {
 /// flank by reference coordinate rather than by strand. See the [module
 /// documentation](crate::structural) for why read direction lives on the
 /// adjacency pair rather than on a breakend.
-///
-/// `Hash` is intentionally not derived because `Position<Interbase>` does not
-/// implement it.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Breakend {
     /// The contig the breakend sits on.
     contig: Contig,

--- a/omics-variation/src/structural/breakend.rs
+++ b/omics-variation/src/structural/breakend.rs
@@ -1,0 +1,214 @@
+//! Breakends.
+
+use std::str::FromStr;
+
+use omics_coordinate::Contig;
+use omics_coordinate::Position;
+use omics_coordinate::contig;
+use omics_coordinate::position::Number;
+use omics_coordinate::position::interbase::Position as InterbasePosition;
+use omics_coordinate::system::Interbase;
+use omics_core::VARIANT_SEPARATOR;
+use thiserror::Error;
+
+use crate::structural::orientation;
+use crate::structural::orientation::Orientation;
+
+/// A parse error related to a [`Breakend`].
+#[derive(Error, Debug)]
+pub enum ParseError {
+    /// The breakend did not have the three colon-separated fields.
+    #[error("invalid breakend format: `{0}`")]
+    Format(String),
+
+    /// The position did not end with the interbase `(i)` qualifier.
+    #[error("position `{position}` must end with `(i)` for an interbase coordinate")]
+    Qualifier {
+        /// The offending position token.
+        position: String,
+    },
+
+    /// The contig failed to parse.
+    #[error(transparent)]
+    Contig(#[from] contig::Error),
+
+    /// The orientation failed to parse.
+    #[error(transparent)]
+    Orientation(#[from] orientation::ParseError),
+
+    /// The position failed to parse.
+    #[error(transparent)]
+    Position(#[from] omics_coordinate::position::Error),
+}
+
+/// One oriented endpoint of a novel adjacency.
+///
+/// A breakend mirrors a coordinate's fields, except that the strand slot is
+/// replaced by an [`Orientation`]. A breakend has no meaningful biological
+/// strand, so it does not carry one.
+///
+/// `Hash` is intentionally not derived because `Position<Interbase>` does not
+/// implement it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Breakend {
+    /// The contig the breakend sits on.
+    contig: Contig,
+
+    /// Which flank of the boundary is retained.
+    orientation: Orientation,
+
+    /// The interbase boundary the breakend sits at.
+    position: Position<Interbase>,
+}
+
+impl Breakend {
+    /// Attempts to create a new [`Breakend`].
+    ///
+    /// The `position` is a raw [`Number`] rather than a generic `impl Into`,
+    /// following the crate convention that non-trait constructors take
+    /// positions concretely so call sites do not need type disambiguation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use omics_variation::structural::breakend::Breakend;
+    /// use omics_variation::structural::orientation::Orientation;
+    ///
+    /// let breakend = Breakend::try_new("seq0", Orientation::LowerFlank, 100)?;
+    /// assert_eq!(breakend.position().get(), 100);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn try_new(
+        contig: impl TryInto<Contig, Error = contig::Error>,
+        orientation: Orientation,
+        position: Number,
+    ) -> Result<Self, contig::Error> {
+        Ok(Self {
+            contig: contig.try_into()?,
+            orientation,
+            position: InterbasePosition::new(position),
+        })
+    }
+
+    /// Gets the contig this breakend sits on.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use omics_variation::structural::breakend::Breakend;
+    /// # use omics_variation::structural::orientation::Orientation;
+    /// let breakend = Breakend::try_new("seq0", Orientation::LowerFlank, 100)?;
+    /// assert_eq!(breakend.contig().as_str(), "seq0");
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn contig(&self) -> &Contig {
+        &self.contig
+    }
+
+    /// Gets the orientation of this breakend.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use omics_variation::structural::breakend::Breakend;
+    /// # use omics_variation::structural::orientation::Orientation;
+    /// let breakend = Breakend::try_new("seq0", Orientation::LowerFlank, 100)?;
+    /// assert_eq!(breakend.orientation(), Orientation::LowerFlank);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn orientation(&self) -> Orientation {
+        self.orientation
+    }
+
+    /// Gets the interbase position of this breakend.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use omics_variation::structural::breakend::Breakend;
+    /// # use omics_variation::structural::orientation::Orientation;
+    /// let breakend = Breakend::try_new("seq0", Orientation::LowerFlank, 100)?;
+    /// assert_eq!(breakend.position().get(), 100);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn position(&self) -> &Position<Interbase> {
+        &self.position
+    }
+
+    /// Gets the canonical ordering key for this breakend.
+    ///
+    /// The key orders breakends first by contig, then by interbase position,
+    /// and finally by orientation rank. It backs the canonical form of a
+    /// paired adjacency.
+    // Consumed by `Adjacency`'s canonical construction, added in the next task.
+    #[allow(dead_code)]
+    pub(crate) fn canonical_key(&self) -> (&str, Number, u8) {
+        (
+            self.contig.as_str(),
+            self.position.get(),
+            self.orientation.rank(),
+        )
+    }
+}
+
+impl FromStr for Breakend {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts = s.split(VARIANT_SEPARATOR).collect::<Vec<_>>();
+        let [contig, orientation, position] = parts.as_slice() else {
+            return Err(ParseError::Format(s.to_string()));
+        };
+
+        let token = position
+            .strip_suffix("(i)")
+            .ok_or_else(|| ParseError::Qualifier {
+                position: (*position).to_string(),
+            })?;
+
+        let position = token.parse::<InterbasePosition>()?;
+
+        Breakend::try_new(*contig, orientation.parse::<Orientation>()?, position.get())
+            .map_err(ParseError::Contig)
+    }
+}
+
+impl std::fmt::Display for Breakend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}{sep}{}{sep}{}(i)",
+            self.contig,
+            self.orientation,
+            self.position.get(),
+            sep = VARIANT_SEPARATOR,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_builds_and_accesses_a_breakend() {
+        let breakend = Breakend::try_new("seq0", Orientation::LowerFlank, 100).unwrap();
+        assert_eq!(breakend.contig().as_str(), "seq0");
+        assert_eq!(breakend.orientation(), Orientation::LowerFlank);
+        assert_eq!(breakend.position().get(), 100);
+    }
+
+    #[test]
+    fn it_parses_and_serializes() {
+        let breakend = "seq0:>:100(i)".parse::<Breakend>().unwrap();
+        assert_eq!(breakend.orientation(), Orientation::LowerFlank);
+        assert_eq!(breakend.position().get(), 100);
+        assert_eq!(breakend.to_string(), "seq0:>:100(i)");
+    }
+
+    #[test]
+    fn it_rejects_a_missing_interbase_qualifier() {
+        let err = "seq0:>:100".parse::<Breakend>().unwrap_err();
+        assert!(matches!(err, ParseError::Qualifier { .. }));
+    }
+}

--- a/omics-variation/src/structural/breakend.rs
+++ b/omics-variation/src/structural/breakend.rs
@@ -140,8 +140,6 @@ impl Breakend {
     /// The key orders breakends first by contig, then by interbase position,
     /// and finally by orientation rank. It backs the canonical form of a
     /// paired adjacency.
-    // Consumed by `Adjacency`'s canonical construction, added in the next task.
-    #[allow(dead_code)]
     pub(crate) fn canonical_key(&self) -> (&str, Number, u8) {
         (
             self.contig.as_str(),

--- a/omics-variation/src/structural/orientation.rs
+++ b/omics-variation/src/structural/orientation.rs
@@ -87,7 +87,10 @@ mod tests {
     #[test]
     fn it_parses_and_serializes() {
         assert_eq!(">".parse::<Orientation>().unwrap(), Orientation::LowerFlank);
-        assert_eq!("<".parse::<Orientation>().unwrap(), Orientation::HigherFlank);
+        assert_eq!(
+            "<".parse::<Orientation>().unwrap(),
+            Orientation::HigherFlank
+        );
         assert_eq!(Orientation::LowerFlank.to_string(), ">");
         assert_eq!(Orientation::HigherFlank.to_string(), "<");
     }

--- a/omics-variation/src/structural/orientation.rs
+++ b/omics-variation/src/structural/orientation.rs
@@ -1,0 +1,105 @@
+//! Breakend orientation.
+
+use std::str::FromStr;
+
+use thiserror::Error;
+
+/// A parse error related to an [`Orientation`].
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum ParseError {
+    /// An invalid orientation glyph was encountered.
+    #[error("invalid orientation: `{0}`")]
+    Invalid(String),
+}
+
+/// Which flank of a breakend's boundary is retained.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Orientation {
+    /// The retained reference is the lower-coordinate flank.
+    ///
+    /// The junction extends onward from the boundary toward higher coordinates.
+    LowerFlank,
+
+    /// The retained reference is the higher-coordinate flank.
+    HigherFlank,
+}
+
+impl Orientation {
+    /// Gets the canonical ordering rank of this [`Orientation`].
+    ///
+    /// [`Orientation::LowerFlank`] ranks before [`Orientation::HigherFlank`].
+    /// The rank is defined explicitly so canonical ordering does not depend on
+    /// the incidental declaration order of the variants.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use omics_variation::structural::orientation::Orientation;
+    ///
+    /// assert!(Orientation::LowerFlank.rank() < Orientation::HigherFlank.rank());
+    /// ```
+    pub fn rank(&self) -> u8 {
+        match self {
+            Orientation::LowerFlank => 0,
+            Orientation::HigherFlank => 1,
+        }
+    }
+
+    /// Reports whether this [`Orientation`] is opposite to another.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use omics_variation::structural::orientation::Orientation;
+    ///
+    /// assert!(Orientation::LowerFlank.is_opposite(Orientation::HigherFlank));
+    /// ```
+    pub fn is_opposite(&self, other: Orientation) -> bool {
+        *self != other
+    }
+}
+
+impl FromStr for Orientation {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            ">" => Ok(Orientation::LowerFlank),
+            "<" => Ok(Orientation::HigherFlank),
+            _ => Err(ParseError::Invalid(s.to_string())),
+        }
+    }
+}
+
+impl std::fmt::Display for Orientation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Orientation::LowerFlank => write!(f, ">"),
+            Orientation::HigherFlank => write!(f, "<"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_parses_and_serializes() {
+        assert_eq!(">".parse::<Orientation>().unwrap(), Orientation::LowerFlank);
+        assert_eq!("<".parse::<Orientation>().unwrap(), Orientation::HigherFlank);
+        assert_eq!(Orientation::LowerFlank.to_string(), ">");
+        assert_eq!(Orientation::HigherFlank.to_string(), "<");
+    }
+
+    #[test]
+    fn it_reports_opposite_orientations() {
+        assert!(Orientation::LowerFlank.is_opposite(Orientation::HigherFlank));
+        assert!(!Orientation::LowerFlank.is_opposite(Orientation::LowerFlank));
+    }
+
+    #[test]
+    fn lower_flank_ranks_before_higher_flank() {
+        assert!(Orientation::LowerFlank.rank() < Orientation::HigherFlank.rank());
+    }
+}

--- a/omics-variation/src/structural/orientation.rs
+++ b/omics-variation/src/structural/orientation.rs
@@ -13,6 +13,14 @@ pub enum ParseError {
 }
 
 /// Which flank of a breakend's boundary is retained.
+///
+/// The flank is named by reference coordinate, not by strand. A breakend has no
+/// strand, so [`LowerFlank`](Orientation::LowerFlank) and
+/// [`HigherFlank`](Orientation::HigherFlank) always refer to the lower and
+/// higher reference-coordinate side of the boundary. Whether the retained piece
+/// is read forward or reverse-complemented in the derivative molecule is not
+/// recorded here; that emerges from how two breakends pair, as described in the
+/// [module documentation](crate::structural).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Orientation {
     /// The retained reference is the lower-coordinate flank.

--- a/omics-variation/tests/structural.rs
+++ b/omics-variation/tests/structural.rs
@@ -1,0 +1,229 @@
+//! Acceptance tests for the six required structural-variant events.
+//!
+//! Each event is constructed through the real, opaque `Adjacency` API and its
+//! derived [`Kind`] is asserted. The swap-invariance tests additionally build
+//! every single-adjacency event with its breakends supplied in both orders,
+//! confirming that canonicalization makes the two adjacencies equal and that
+//! their enclosing structural variants classify identically.
+
+use omics_coordinate::position::Number;
+use omics_molecule::polymer::dna;
+use omics_variation::StructuralVariant;
+use omics_variation::structural::Kind;
+use omics_variation::structural::Locality;
+use omics_variation::structural::adjacency::Adjacency;
+use omics_variation::structural::breakend::Breakend;
+use omics_variation::structural::orientation::Orientation;
+
+/// A DNA structural variant used by these acceptance tests.
+type Sv = StructuralVariant<dna::Nucleotide>;
+
+/// Builds a breakend on the named contig.
+fn bnd(contig: &str, orientation: Orientation, position: Number) -> Breakend {
+    Breakend::try_new(contig, orientation, position).unwrap()
+}
+
+/// Builds a paired adjacency from two breakends and an insertion token.
+fn paired(x: Breakend, y: Breakend, insertion: &str) -> Adjacency<dna::Nucleotide> {
+    Adjacency::try_new_paired(x, y, insertion.parse().unwrap()).unwrap()
+}
+
+/// Asserts that a single-adjacency event built in both breakend orders is
+/// order-invariant.
+///
+/// The junction is supplied once as `(x, y)` with `insertion_forward` and once
+/// as `(y, x)` with `insertion_reversed`. Because canonicalization reverse
+/// complements the insertion of whichever call it reorders, the two adjacencies
+/// must be equal, and both enclosing structural variants must classify as
+/// `expected`.
+fn assert_swap_invariant(
+    x: Breakend,
+    y: Breakend,
+    insertion_forward: &str,
+    insertion_reversed: &str,
+    expected: Kind,
+) {
+    let forward = Adjacency::<dna::Nucleotide>::try_new_paired(
+        x.clone(),
+        y.clone(),
+        insertion_forward.parse().unwrap(),
+    )
+    .unwrap();
+    let backward =
+        Adjacency::<dna::Nucleotide>::try_new_paired(y, x, insertion_reversed.parse().unwrap())
+            .unwrap();
+
+    assert_eq!(forward, backward, "swapped-order adjacencies must be equal");
+
+    let forward_variant = Sv::try_new(vec![forward]).unwrap();
+    let backward_variant = Sv::try_new(vec![backward]).unwrap();
+
+    assert_eq!(forward_variant, backward_variant);
+    assert_eq!(forward_variant.kind(), expected);
+    assert_eq!(backward_variant.kind(), expected);
+}
+
+#[test]
+fn large_deletion() {
+    let adjacency = paired(
+        bnd("seq0", Orientation::LowerFlank, 100),
+        bnd("seq0", Orientation::HigherFlank, 5000),
+        ".",
+    );
+    assert_eq!(Sv::try_new(vec![adjacency]).unwrap().kind(), Kind::Deletion);
+}
+
+#[test]
+fn large_insertion() {
+    let adjacency = paired(
+        bnd("seq0", Orientation::LowerFlank, 100),
+        bnd("seq0", Orientation::HigherFlank, 100),
+        "ACGTACGTACGT",
+    );
+    assert_eq!(
+        Sv::try_new(vec![adjacency]).unwrap().kind(),
+        Kind::Insertion
+    );
+}
+
+#[test]
+fn interchromosomal_translocation() {
+    let adjacency = paired(
+        bnd("seq0", Orientation::LowerFlank, 100),
+        bnd("seq1", Orientation::HigherFlank, 900),
+        ".",
+    );
+    assert_eq!(
+        Sv::try_new(vec![adjacency]).unwrap().kind(),
+        Kind::Translocation(Locality::Interchromosomal)
+    );
+}
+
+#[test]
+fn intrachromosomal_translocation() {
+    // A balanced forward relocation: three co-linear junctions over the three
+    // boundaries {100, 200, 400}, each appearing once as a lower flank and once
+    // as a higher flank across the junctions.
+    let origin = paired(
+        bnd("seq0", Orientation::LowerFlank, 100),
+        bnd("seq0", Orientation::HigherFlank, 200),
+        ".",
+    );
+    let target_left = paired(
+        bnd("seq0", Orientation::LowerFlank, 400),
+        bnd("seq0", Orientation::HigherFlank, 100),
+        ".",
+    );
+    let target_right = paired(
+        bnd("seq0", Orientation::LowerFlank, 200),
+        bnd("seq0", Orientation::HigherFlank, 400),
+        ".",
+    );
+    assert_eq!(
+        Sv::try_new(vec![origin, target_left, target_right])
+            .unwrap()
+            .kind(),
+        Kind::Translocation(Locality::Intrachromosomal)
+    );
+}
+
+#[test]
+fn inversion() {
+    let lower = paired(
+        bnd("seq0", Orientation::LowerFlank, 100),
+        bnd("seq0", Orientation::LowerFlank, 300),
+        ".",
+    );
+    let higher = paired(
+        bnd("seq0", Orientation::HigherFlank, 100),
+        bnd("seq0", Orientation::HigherFlank, 300),
+        ".",
+    );
+    assert_eq!(
+        Sv::try_new(vec![lower, higher]).unwrap().kind(),
+        Kind::Inversion
+    );
+}
+
+#[test]
+fn internal_tandem_duplication() {
+    let adjacency = paired(
+        bnd("seq0", Orientation::HigherFlank, 100),
+        bnd("seq0", Orientation::LowerFlank, 160),
+        "GAT",
+    );
+    assert_eq!(
+        Sv::try_new(vec![adjacency]).unwrap().kind(),
+        Kind::TandemDuplication
+    );
+}
+
+#[test]
+fn deletion_is_swap_invariant() {
+    assert_swap_invariant(
+        bnd("seq0", Orientation::LowerFlank, 100),
+        bnd("seq0", Orientation::HigherFlank, 5000),
+        ".",
+        ".",
+        Kind::Deletion,
+    );
+}
+
+#[test]
+fn insertion_is_swap_invariant() {
+    // `AAAC` forward reverse-complements to `GTTT`, so the swapped call must be
+    // supplied `GTTT` to land on the same canonical insertion.
+    assert_swap_invariant(
+        bnd("seq0", Orientation::LowerFlank, 100),
+        bnd("seq0", Orientation::HigherFlank, 100),
+        "AAAC",
+        "GTTT",
+        Kind::Insertion,
+    );
+}
+
+#[test]
+fn tandem_duplication_is_swap_invariant() {
+    assert_swap_invariant(
+        bnd("seq0", Orientation::HigherFlank, 100),
+        bnd("seq0", Orientation::LowerFlank, 160),
+        "AAAC",
+        "GTTT",
+        Kind::TandemDuplication,
+    );
+}
+
+#[test]
+fn interchromosomal_translocation_is_swap_invariant() {
+    assert_swap_invariant(
+        bnd("seq0", Orientation::LowerFlank, 100),
+        bnd("seq1", Orientation::HigherFlank, 900),
+        ".",
+        ".",
+        Kind::Translocation(Locality::Interchromosomal),
+    );
+}
+
+#[test]
+fn reverse_complement_lands_in_the_canonical_frame() {
+    // The same physical junction supplied in both orders must classify the same,
+    // and the insertion must be reverse-complemented into the canonical frame.
+    // `AAAC` reverse-complements to `GTTT`, so the two orders differ observably
+    // in their stored insertion when the reversed call is supplied `AAAC`.
+    let lo = bnd("seq0", Orientation::LowerFlank, 100);
+    let hi = bnd("seq0", Orientation::HigherFlank, 200);
+
+    let forward = Adjacency::<dna::Nucleotide>::try_new_paired(
+        lo.clone(),
+        hi.clone(),
+        "AAAC".parse().unwrap(),
+    )
+    .unwrap();
+    let backward =
+        Adjacency::<dna::Nucleotide>::try_new_paired(hi, lo, "AAAC".parse().unwrap()).unwrap();
+
+    let (_, _, forward_insertion) = forward.paired().expect("a paired adjacency");
+    let (_, _, backward_insertion) = backward.paired().expect("a paired adjacency");
+    assert_eq!(forward_insertion.to_string(), "AAAC");
+    assert_eq!(backward_insertion.to_string(), "GTTT");
+}

--- a/omics-variation/tests/structural.rs
+++ b/omics-variation/tests/structural.rs
@@ -222,8 +222,12 @@ fn reverse_complement_lands_in_the_canonical_frame() {
     let backward =
         Adjacency::<dna::Nucleotide>::try_new_paired(hi, lo, "AAAC".parse().unwrap()).unwrap();
 
-    let (_, _, forward_insertion) = forward.paired().expect("a paired adjacency");
-    let (_, _, backward_insertion) = backward.paired().expect("a paired adjacency");
-    assert_eq!(forward_insertion.to_string(), "AAAC");
-    assert_eq!(backward_insertion.to_string(), "GTTT");
+    let Adjacency::Paired(forward) = forward else {
+        panic!("expected a paired adjacency");
+    };
+    let Adjacency::Paired(backward) = backward else {
+        panic!("expected a paired adjacency");
+    };
+    assert_eq!(forward.insertion().to_string(), "AAAC");
+    assert_eq!(backward.insertion().to_string(), "GTTT");
 }

--- a/omics-variation/tests/structural.rs
+++ b/omics-variation/tests/structural.rs
@@ -163,8 +163,8 @@ fn deletion_is_swap_invariant() {
     assert_swap_invariant(
         bnd("seq0", Orientation::LowerFlank, 100),
         bnd("seq0", Orientation::HigherFlank, 5000),
-        ".",
-        ".",
+        "AAAC",
+        "GTTT",
         Kind::Deletion,
     );
 }
@@ -198,8 +198,8 @@ fn interchromosomal_translocation_is_swap_invariant() {
     assert_swap_invariant(
         bnd("seq0", Orientation::LowerFlank, 100),
         bnd("seq1", Orientation::HigherFlank, 900),
-        ".",
-        ".",
+        "AAAC",
+        "GTTT",
         Kind::Translocation(Locality::Interchromosomal),
     );
 }

--- a/omics-variation/tests/structural.rs
+++ b/omics-variation/tests/structural.rs
@@ -9,6 +9,7 @@
 use omics_coordinate::position::Number;
 use omics_molecule::polymer::dna;
 use omics_variation::StructuralVariant;
+use omics_variation::structural::Join;
 use omics_variation::structural::Kind;
 use omics_variation::structural::Locality;
 use omics_variation::structural::adjacency::Adjacency;
@@ -95,7 +96,10 @@ fn interchromosomal_translocation() {
     );
     assert_eq!(
         Sv::try_new(vec![adjacency]).unwrap().kind(),
-        Kind::Translocation(Locality::Interchromosomal)
+        Kind::Translocation {
+            locality: Locality::Interchromosomal,
+            join: Join::CoLinear
+        }
     );
 }
 
@@ -123,7 +127,10 @@ fn intrachromosomal_translocation() {
         Sv::try_new(vec![origin, target_left, target_right])
             .unwrap()
             .kind(),
-        Kind::Translocation(Locality::Intrachromosomal)
+        Kind::Translocation {
+            locality: Locality::Intrachromosomal,
+            join: Join::CoLinear
+        }
     );
 }
 
@@ -200,7 +207,10 @@ fn interchromosomal_translocation_is_swap_invariant() {
         bnd("seq1", Orientation::HigherFlank, 900),
         "AAAC",
         "GTTT",
-        Kind::Translocation(Locality::Interchromosomal),
+        Kind::Translocation {
+            locality: Locality::Interchromosomal,
+            join: Join::CoLinear,
+        },
     );
 }
 


### PR DESCRIPTION
Added a structural-variant tier to `omics-variation`, built on the breakend-adjacency model where a structural variant's kind is derived from breakend geometry rather than stored, mirroring how the small-variant tier derives its kind from allele content. The tier introduces an `Orientation`, a `Breakend` (a locus plus which flank is retained), an opaque `Adjacency` that canonicalizes its two breakends and reverse-complements the non-templated insertion when their order is swapped, and a `StructuralVariant` that normalizes its adjacencies and classifies deletions, insertions, tandem duplications, inversions, translocations, single-ended breakends, and complex events.

Supporting the tier, `omics-molecule` gained a `Complement` trait and a `Sequence::reverse_complement` method, and the small-variant tier moved into a `small` module with its previous paths preserved through re-exports. The workspace Rust floor rose to `1.81` for the `#[expect]` attribute the benchmarks use.

For reviewers: this pass recognizes only the balanced forward relocation for intrachromosomal translocations, so inverted-reinsertion relocations, reciprocal translocations, and other multi-junction shapes classify as complex. Reserved separators in contig names are not escaped, which is consistent with the existing variant string format.

Before submitting this PR, please make sure:

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
