### PR TITLE
feat: add `omics-alignment` algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ following features are included and are top-level goals of the project.
   _interbase_ coordinate system) and 1-based, fully-closed coordinate system (also known
   as the _in-base_ or just _base_ coordinate system).
 - **Sequence alignments (`omics::alignment`).** Validated pairwise alignments with
-  lossless per-operation traversal via `Alignment::steps`; callers can select aligned
-  operations with `Step::is_aligned`. No dependency on SAM records, BAM, PAF, or
-  chainfile libraries.
+  deterministic global and local affine-gap alignment over generic symbol slices,
+  plus lossless per-operation traversal via `Alignment::steps`; callers can select
+  aligned operations with `Step::is_aligned`. No dependency on SAM records, BAM,
+  PAF, or chainfile libraries.
 - **Biologically relevant molecules (`omics::molecule`).** Representations of molecules
   relevant in omics including smaller compounds (e.g., nucleotides) and larger
   polymers (e.g., DNA, RNA).

--- a/omics-alignment/CHANGELOG.md
+++ b/omics-alignment/CHANGELOG.md
@@ -21,4 +21,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#18](https://github.com/stjude-rust-labs/omics/pull/18)).
 * Added generic global and local affine-gap alignment with deterministic canonical
   CIGAR output using `=`, `X`, `I`, and `D`, plus returned half-open local input
-  ranges that place each result on the original sequences.
+  ranges that place each result on the original sequences
+  ([#19](https://github.com/stjude-rust-labs/omics/pull/19)).

--- a/omics-alignment/CHANGELOG.md
+++ b/omics-alignment/CHANGELOG.md
@@ -19,3 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   losslessly, and `Step::is_aligned` supports filtering to aligned operations
   (`M`, `=`, `X`) without discarding operation boundaries
   ([#18](https://github.com/stjude-rust-labs/omics/pull/18)).
+* Added generic global and local affine-gap alignment with deterministic canonical
+  CIGAR output using `=`, `X`, `I`, and `D`, plus returned half-open local input
+  ranges that place each result on the original sequences.

--- a/omics-alignment/Cargo.toml
+++ b/omics-alignment/Cargo.toml
@@ -17,5 +17,8 @@ thiserror.workspace = true
 default = []
 position-u64 = ["omics-coordinate/position-u64"]
 
+[dev-dependencies]
+omics-molecule = { path = "../omics-molecule", version = "0.2.0" }
+
 [lints]
 workspace = true

--- a/omics-alignment/Cargo.toml
+++ b/omics-alignment/Cargo.toml
@@ -18,7 +18,14 @@ default = []
 position-u64 = ["omics-coordinate/position-u64"]
 
 [dev-dependencies]
+criterion.workspace = true
 omics-molecule = { path = "../omics-molecule", version = "0.2.0" }
 
 [lints]
 workspace = true
+
+# Benchmarks
+
+[[bench]]
+name = "algorithms"
+harness = false

--- a/omics-alignment/benches/algorithms.rs
+++ b/omics-alignment/benches/algorithms.rs
@@ -1,0 +1,99 @@
+//! Benchmarks for global and local alignment algorithms.
+#![expect(
+    missing_docs,
+    reason = "criterion_group generates undocumented registration functions"
+)]
+
+use std::hint::black_box;
+
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use criterion::Throughput;
+use criterion::criterion_group;
+use criterion::criterion_main;
+use omics_alignment::algorithm::Scoring;
+use omics_alignment::algorithm::global;
+use omics_alignment::algorithm::local;
+
+/// Equal input lengths used to measure quadratic scaling.
+const SIZES: [usize; 3] = [16, 64, 256];
+
+/// Builds equal-length, mostly matching DNA-like benchmark inputs.
+fn fixture(size: usize) -> (Vec<u8>, Vec<u8>) {
+    let reference = (0..size)
+        .map(|index| b"ACGT"[index % 4])
+        .collect::<Vec<_>>();
+    let mut query = reference.clone();
+
+    for start in (0..size).step_by(16) {
+        query[start + 3] = b'A';
+        query[start + 8..start + 12].rotate_left(1);
+    }
+
+    (reference, query)
+}
+
+/// Constructs the scoring configuration shared by every benchmark.
+fn scoring() -> Scoring {
+    // SAFETY: the benchmark scores satisfy all Scoring sign constraints.
+    Scoring::try_new(2, -3, -2, -1).unwrap()
+}
+
+/// Returns the number of dynamic-programming cells for equal-length inputs.
+fn cells(size: usize) -> u64 {
+    ((size + 1) * (size + 1)) as u64
+}
+
+/// Registers end-to-end global-alignment scaling benchmarks.
+fn global_benches(c: &mut Criterion) {
+    let scoring = scoring();
+    let mut group = c.benchmark_group("algorithms/global");
+
+    for size in SIZES {
+        let (reference, query) = fixture(size);
+        group.throughput(Throughput::Elements(cells(size)));
+        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, _| {
+            b.iter(|| {
+                match global(
+                    black_box(reference.as_slice()),
+                    black_box(query.as_slice()),
+                    scoring,
+                ) {
+                    Ok(outcome) => black_box(outcome),
+                    Err(error) => panic!("global benchmark failed; {error}"),
+                }
+            })
+        });
+    }
+
+    group.finish();
+}
+
+/// Registers end-to-end local-alignment scaling benchmarks.
+fn local_benches(c: &mut Criterion) {
+    let scoring = scoring();
+    let mut group = c.benchmark_group("algorithms/local");
+
+    for size in SIZES {
+        let (reference, query) = fixture(size);
+        group.throughput(Throughput::Elements(cells(size)));
+        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, _| {
+            b.iter(|| {
+                match local(
+                    black_box(reference.as_slice()),
+                    black_box(query.as_slice()),
+                    scoring,
+                ) {
+                    Ok(Some(outcome)) => black_box(outcome),
+                    Ok(None) => panic!("local benchmark produced no positive alignment"),
+                    Err(error) => panic!("local benchmark failed; {error}"),
+                }
+            })
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, global_benches, local_benches);
+criterion_main!(benches);

--- a/omics-alignment/src/algorithm.rs
+++ b/omics-alignment/src/algorithm.rs
@@ -218,6 +218,15 @@ pub fn global<T: Eq>(reference: &[T], query: &[T], scoring: Scoring) -> Result<O
     engine::global(reference, query, scoring)
 }
 
+/// Computes the highest-scoring positive local affine-gap alignment.
+pub fn local<T: Eq>(
+    reference: &[T],
+    query: &[T],
+    scoring: Scoring,
+) -> Result<Option<Outcome>, Error> {
+    engine::local(reference, query, scoring)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -313,6 +322,48 @@ mod tests {
             global(b"", b"AA", scoring),
             Err(Error::ScoreOverflow)
         ));
+        Ok(())
+    }
+
+    #[test]
+    fn local_returns_best_positive_subsequences() -> Result<(), Error> {
+        let scoring = Scoring::try_new(2, -3, -2, -1)?;
+        let outcome = local(b"GGACGTCC", b"TTACGAAA", scoring)?.unwrap();
+        assert_eq!(outcome.score(), 6);
+        assert_eq!(outcome.cigar().to_string(), "3=");
+        assert_eq!(outcome.reference_range(), &(2..5));
+        assert_eq!(outcome.query_range(), &(2..5));
+        Ok(())
+    }
+
+    #[test]
+    fn local_returns_none_without_a_positive_alignment() -> Result<(), Error> {
+        let scoring = Scoring::try_new(2, -3, -2, -1)?;
+        assert!(local(b"AAAA", b"CCCC", scoring)?.is_none());
+        assert!(local::<u8>(b"", b"", scoring)?.is_none());
+        assert!(local(b"", b"AAAA", scoring)?.is_none());
+        assert!(local(b"AAAA", b"", scoring)?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn local_trims_zero_cost_leading_gaps() -> Result<(), Error> {
+        let scoring = Scoring::try_new(1, 0, 0, 0)?;
+        let outcome = local(b"A", b"BA", scoring)?.unwrap();
+        assert_eq!(outcome.score(), 1);
+        assert_eq!(outcome.cigar().to_string(), "1=");
+        assert_eq!(outcome.reference_range(), &(0..1));
+        assert_eq!(outcome.query_range(), &(1..2));
+        Ok(())
+    }
+
+    #[test]
+    fn local_chooses_the_earliest_equal_endpoint() -> Result<(), Error> {
+        let scoring = Scoring::try_new(1, 0, 0, 0)?;
+        let outcome = local(b"AA", b"A", scoring)?.unwrap();
+        assert_eq!(outcome.cigar().to_string(), "1=");
+        assert_eq!(outcome.reference_range(), &(0..1));
+        assert_eq!(outcome.query_range(), &(0..1));
         Ok(())
     }
 }

--- a/omics-alignment/src/algorithm.rs
+++ b/omics-alignment/src/algorithm.rs
@@ -251,7 +251,7 @@ pub enum Error {
     #[error("alignment matrix dimensions overflow usize")]
     MatrixSizeOverflow,
     /// Matrix memory could not be reserved.
-    #[error("failed to allocate alignment matrix")]
+    #[error("failed to allocate alignment storage")]
     MatrixAllocation {
         /// Allocation failure reported by `Vec`.
         #[source]

--- a/omics-alignment/src/algorithm.rs
+++ b/omics-alignment/src/algorithm.rs
@@ -1,4 +1,59 @@
-//! Pairwise global and local sequence-alignment algorithms.
+//! Deterministic global and local affine-gap sequence alignment.
+//!
+//! This module computes pairwise alignments over generic symbol slices
+//! `&[T]` where `T: Eq`. Call [`crate::algorithm::global`] to align both
+//! complete inputs. Call [`crate::algorithm::local`] to align the
+//! highest-scoring positive subsequences and receive `Ok(None)` when either
+//! input is empty or no positive local alignment exists.
+//!
+//! # Scoring
+//!
+//! [`crate::algorithm::Scoring`] stores four signed scores. A gap of length
+//! `L` contributes `gap_open_score + (L - 1) * gap_extend_score`.
+//!
+//! # Output
+//!
+//! [`crate::algorithm::Outcome`] stores the alignment score, a canonical
+//! [`crate::cigar::Cigar`], and half-open input ranges. These algorithms
+//! emit only `=`, `X`, `I`, and `D`. `=` records equal symbols. `X` records
+//! unequal symbols. `I` records a query-only gap. `D` records a
+//! reference-only gap. They never emit `M`. Adjacent identical operations
+//! coalesce into one run.
+//!
+//! The returned ranges are zero-based indexes into the original inputs.
+//! [`crate::algorithm::global`] always returns
+//! `0..reference.len()` and `0..query.len()`. [`crate::algorithm::local`]
+//! returns the best-scoring subsequence ranges, and the returned CIGAR starts
+//! at `reference_range().start` and `query_range().start` within the original
+//! inputs. Callers that need genomic placement can advance the reference and
+//! query coordinates for input index `0` by those starts and then pass the
+//! returned CIGAR to [`crate::Alignment::try_new`].
+//!
+//! # Determinism
+//!
+//! Equal scores resolve through a fixed policy. Aligned predecessors prefer
+//! aligned, then deletion, then insertion. Insertion predecessors prefer
+//! insertion, then aligned, then deletion. Deletion predecessors prefer
+//! deletion, then aligned, then insertion. Global endpoint selection prefers
+//! aligned, then deletion, then insertion. Local endpoint selection keeps the
+//! first positive maximum in row-major order over exclusive
+//! `(reference_end, query_end)` pairs.
+//!
+//! # Example
+//!
+//! ```
+//! use omics_alignment::algorithm::Scoring;
+//! use omics_alignment::algorithm::local;
+//!
+//! let scoring = Scoring::try_new(2, -3, -2, -1)?;
+//! let outcome = local(b"GGACGT", b"TTACGA", scoring)?.unwrap();
+//!
+//! assert_eq!(outcome.score(), 6);
+//! assert_eq!(outcome.cigar().to_string(), "3=");
+//! assert_eq!(outcome.reference_range(), &(2..5));
+//! assert_eq!(outcome.query_range(), &(2..5));
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
 
 use std::collections::TryReserveError;
 use std::ops::Range;
@@ -26,7 +81,11 @@ pub struct Scoring {
 }
 
 impl Scoring {
-    /// Constructs scoring values accepted by global and local alignment.
+    /// Constructs scoring values accepted by [`global`] and [`local`].
+    ///
+    /// `match_score` must be positive. `mismatch_score`, `gap_open_score`,
+    /// and `gap_extend_score` must be non-positive. A gap of length `L`
+    /// contributes `gap_open_score + (L - 1) * gap_extend_score`.
     pub fn try_new(
         match_score: Score,
         mismatch_score: Score,
@@ -90,7 +149,7 @@ impl Scoring {
     }
 }
 
-/// The result of one non-empty pairwise alignment.
+/// The result of one deterministic non-empty pairwise alignment.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Outcome {
     /// Alignment score.
@@ -115,11 +174,17 @@ impl Outcome {
     }
 
     /// Returns the half-open reference input range.
+    ///
+    /// This start index places the first CIGAR operation on the original
+    /// reference input.
     pub const fn reference_range(&self) -> &Range<usize> {
         &self.reference_range
     }
 
     /// Returns the half-open query input range.
+    ///
+    /// This start index places the first CIGAR operation on the original
+    /// query input.
     pub const fn query_range(&self) -> &Range<usize> {
         &self.query_range
     }
@@ -213,12 +278,23 @@ pub enum Error {
 /// Dynamic-programming and traceback implementation.
 mod engine;
 
-/// Computes a global affine-gap alignment over two complete inputs.
+/// Computes a deterministic global affine-gap alignment over two complete
+/// inputs.
+///
+/// This function accepts generic symbol slices `&[T]` where `T: Eq`. The
+/// returned ranges always span both complete inputs. If both inputs are
+/// empty, the function returns [`Error::EmptyGlobal`] because the CIGAR model
+/// cannot represent a zero-operation traversal.
 pub fn global<T: Eq>(reference: &[T], query: &[T], scoring: Scoring) -> Result<Outcome, Error> {
     engine::global(reference, query, scoring)
 }
 
 /// Computes the highest-scoring positive local affine-gap alignment.
+///
+/// This function accepts generic symbol slices `&[T]` where `T: Eq`.
+/// `Ok(None)` means that either input is empty or no positive-scoring local
+/// alignment exists. Successful results report half-open subsequence ranges in
+/// the original inputs, and their CIGAR begins and ends with `=` or `X`.
 pub fn local<T: Eq>(
     reference: &[T],
     query: &[T],

--- a/omics-alignment/src/algorithm.rs
+++ b/omics-alignment/src/algorithm.rs
@@ -1,0 +1,237 @@
+//! Pairwise global and local sequence-alignment algorithms.
+
+use std::collections::TryReserveError;
+use std::ops::Range;
+
+use thiserror::Error;
+
+use crate::cigar::Axis;
+use crate::cigar::Cigar;
+use crate::cigar::OperationError;
+
+/// A score used by pairwise alignment algorithms.
+pub type Score = i64;
+
+/// Validated scores for pairwise alignment.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Scoring {
+    /// Score for equal symbols.
+    match_score: Score,
+    /// Score for unequal symbols.
+    mismatch_score: Score,
+    /// Score for the first symbol in a gap.
+    gap_open_score: Score,
+    /// Score for each additional symbol in a gap.
+    gap_extend_score: Score,
+}
+
+impl Scoring {
+    /// Constructs scoring values accepted by global and local alignment.
+    pub fn try_new(
+        match_score: Score,
+        mismatch_score: Score,
+        gap_open_score: Score,
+        gap_extend_score: Score,
+    ) -> Result<Self, Error> {
+        if match_score <= 0 {
+            return Err(Error::InvalidMatchScore { score: match_score });
+        }
+        if mismatch_score > 0 {
+            return Err(Error::InvalidMismatchScore {
+                score: mismatch_score,
+            });
+        }
+        if gap_open_score > 0 {
+            return Err(Error::InvalidGapOpenScore {
+                score: gap_open_score,
+            });
+        }
+        if gap_extend_score > 0 {
+            return Err(Error::InvalidGapExtendScore {
+                score: gap_extend_score,
+            });
+        }
+
+        Ok(Self {
+            match_score,
+            mismatch_score,
+            gap_open_score,
+            gap_extend_score,
+        })
+    }
+
+    /// Returns the score for equal symbols.
+    pub const fn match_score(self) -> Score {
+        self.match_score
+    }
+
+    /// Returns the score for unequal symbols.
+    pub const fn mismatch_score(self) -> Score {
+        self.mismatch_score
+    }
+
+    /// Returns the score for the first symbol in a gap.
+    pub const fn gap_open_score(self) -> Score {
+        self.gap_open_score
+    }
+
+    /// Returns the score for each additional symbol in a gap.
+    pub const fn gap_extend_score(self) -> Score {
+        self.gap_extend_score
+    }
+}
+
+/// The result of one non-empty pairwise alignment.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Outcome {
+    /// Alignment score.
+    score: Score,
+    /// Canonical alignment operations.
+    cigar: Cigar,
+    /// Covered half-open reference input range.
+    reference_range: Range<usize>,
+    /// Covered half-open query input range.
+    query_range: Range<usize>,
+}
+
+impl Outcome {
+    /// Returns the alignment score.
+    pub const fn score(&self) -> Score {
+        self.score
+    }
+
+    /// Returns the canonical CIGAR.
+    pub const fn cigar(&self) -> &Cigar {
+        &self.cigar
+    }
+
+    /// Returns the half-open reference input range.
+    pub const fn reference_range(&self) -> &Range<usize> {
+        &self.reference_range
+    }
+
+    /// Returns the half-open query input range.
+    pub const fn query_range(&self) -> &Range<usize> {
+        &self.query_range
+    }
+}
+
+/// An error produced while configuring or computing an alignment.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// The match score was not positive.
+    #[error("match score must be positive, got {score}")]
+    InvalidMatchScore {
+        /// Invalid score supplied by the caller.
+        score: Score,
+    },
+    /// The mismatch score was positive.
+    #[error("mismatch score must be non-positive, got {score}")]
+    InvalidMismatchScore {
+        /// Invalid score supplied by the caller.
+        score: Score,
+    },
+    /// The gap-open score was positive.
+    #[error("gap-open score must be non-positive, got {score}")]
+    InvalidGapOpenScore {
+        /// Invalid score supplied by the caller.
+        score: Score,
+    },
+    /// The gap-extension score was positive.
+    #[error("gap-extension score must be non-positive, got {score}")]
+    InvalidGapExtendScore {
+        /// Invalid score supplied by the caller.
+        score: Score,
+    },
+    /// Both inputs to global alignment were empty.
+    #[error("a global alignment of two empty inputs has no representable CIGAR")]
+    EmptyGlobal,
+    /// An input length did not fit the active coordinate number type.
+    #[error("{axis} input length {length} does not fit the configured CIGAR length type")]
+    LengthOutOfRange {
+        /// Input axis whose length is not representable.
+        axis: Axis,
+        /// Unrepresentable slice length.
+        length: usize,
+    },
+    /// Matrix row and column multiplication overflowed.
+    #[error("alignment matrix dimensions overflow usize")]
+    MatrixSizeOverflow,
+    /// Matrix memory could not be reserved.
+    #[error("failed to allocate alignment matrix")]
+    MatrixAllocation {
+        /// Allocation failure reported by `Vec`.
+        #[source]
+        source: TryReserveError,
+    },
+    /// Checked score arithmetic overflowed.
+    #[error("alignment score arithmetic overflowed i64")]
+    ScoreOverflow,
+    /// A reachable endpoint produced an empty or incomplete traceback.
+    #[error("alignment traceback invariant failed")]
+    TracebackInvariant,
+    /// A traceback operation could not be constructed.
+    #[error("failed to construct a traceback operation")]
+    Operation {
+        /// Checked operation-construction failure.
+        #[from]
+        source: OperationError,
+    },
+    /// The checked operation list could not form a CIGAR.
+    #[error("failed to construct the alignment CIGAR")]
+    Cigar {
+        /// Checked CIGAR-construction failure.
+        #[from]
+        source: crate::cigar::Error,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scoring_accepts_valid_boundaries() -> Result<(), Error> {
+        let scoring = Scoring::try_new(2, 0, 0, -1)?;
+        assert_eq!(scoring.match_score(), 2);
+        assert_eq!(scoring.mismatch_score(), 0);
+        assert_eq!(scoring.gap_open_score(), 0);
+        assert_eq!(scoring.gap_extend_score(), -1);
+        Ok(())
+    }
+
+    #[test]
+    fn scoring_rejects_invalid_signs() {
+        assert!(matches!(
+            Scoring::try_new(0, -1, -2, -1),
+            Err(Error::InvalidMatchScore { score: 0 })
+        ));
+        assert!(matches!(
+            Scoring::try_new(1, 1, -2, -1),
+            Err(Error::InvalidMismatchScore { score: 1 })
+        ));
+        assert!(matches!(
+            Scoring::try_new(1, -1, 1, -1),
+            Err(Error::InvalidGapOpenScore { score: 1 })
+        ));
+        assert!(matches!(
+            Scoring::try_new(1, -1, -2, 1),
+            Err(Error::InvalidGapExtendScore { score: 1 })
+        ));
+    }
+
+    #[test]
+    fn outcome_exposes_immutable_result_parts() -> Result<(), Box<dyn std::error::Error>> {
+        let outcome = Outcome {
+            score: 7,
+            cigar: "2=1X".parse()?,
+            reference_range: 3..6,
+            query_range: 5..8,
+        };
+        assert_eq!(outcome.score(), 7);
+        assert_eq!(outcome.cigar().to_string(), "2=1X");
+        assert_eq!(outcome.reference_range(), &(3..6));
+        assert_eq!(outcome.query_range(), &(5..8));
+        Ok(())
+    }
+}

--- a/omics-alignment/src/algorithm.rs
+++ b/omics-alignment/src/algorithm.rs
@@ -25,9 +25,13 @@
 //! `0..reference.len()` and `0..query.len()`. [`crate::algorithm::local`]
 //! returns the best-scoring subsequence ranges, and the returned CIGAR starts
 //! at `reference_range().start` and `query_range().start` within the original
-//! inputs. Callers that need genomic placement can advance the reference and
-//! query coordinates for input index `0` by those starts and then pass the
-//! returned CIGAR to [`crate::Alignment::try_new`].
+//! inputs. Callers that need genomic placement can apply
+//! `reference_range().start` and `query_range().start` with
+//! [`Coordinate::move_forward`](omics_coordinate::Coordinate::move_forward)
+//! to coordinates that represent input index `0` before calling
+//! [`crate::Alignment::try_new`]. `move_forward` advances positions on the
+//! positive strand and retreats them on the negative strand, so the offset
+//! follows sequence traversal direction.
 //!
 //! # Determinism
 //!

--- a/omics-alignment/src/algorithm.rs
+++ b/omics-alignment/src/algorithm.rs
@@ -79,6 +79,15 @@ impl Scoring {
     pub const fn gap_extend_score(self) -> Score {
         self.gap_extend_score
     }
+
+    /// Returns the match or mismatch score for two symbols.
+    pub(crate) fn substitution<T: Eq>(self, reference: &T, query: &T) -> Score {
+        if reference == query {
+            self.match_score
+        } else {
+            self.mismatch_score
+        }
+    }
 }
 
 /// The result of one non-empty pairwise alignment.
@@ -113,6 +122,21 @@ impl Outcome {
     /// Returns the half-open query input range.
     pub const fn query_range(&self) -> &Range<usize> {
         &self.query_range
+    }
+
+    /// Constructs an outcome from a checked traceback.
+    pub(crate) fn new(
+        score: Score,
+        cigar: Cigar,
+        reference_range: Range<usize>,
+        query_range: Range<usize>,
+    ) -> Self {
+        Self {
+            score,
+            cigar,
+            reference_range,
+            query_range,
+        }
     }
 }
 
@@ -186,6 +210,14 @@ pub enum Error {
     },
 }
 
+/// Dynamic-programming and traceback implementation.
+mod engine;
+
+/// Computes a global affine-gap alignment over two complete inputs.
+pub fn global<T: Eq>(reference: &[T], query: &[T], scoring: Scoring) -> Result<Outcome, Error> {
+    engine::global(reference, query, scoring)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -232,6 +264,55 @@ mod tests {
         assert_eq!(outcome.cigar().to_string(), "2=1X");
         assert_eq!(outcome.reference_range(), &(3..6));
         assert_eq!(outcome.query_range(), &(5..8));
+        Ok(())
+    }
+
+    #[test]
+    fn global_aligns_matches_and_one_deletion() -> Result<(), Error> {
+        let scoring = Scoring::try_new(2, -3, -2, -1)?;
+        let outcome = global(b"ACGT", b"AGT", scoring)?;
+        assert_eq!(outcome.score(), 4);
+        assert_eq!(outcome.cigar().to_string(), "1=1D2=");
+        assert_eq!(outcome.reference_range(), &(0..4));
+        assert_eq!(outcome.query_range(), &(0..3));
+        Ok(())
+    }
+
+    #[test]
+    fn global_prefers_two_gaps_to_an_expensive_mismatch() -> Result<(), Error> {
+        let scoring = Scoring::try_new(1, -5, -1, -1)?;
+        let outcome = global(b"A", b"B", scoring)?;
+        assert_eq!(outcome.score(), -2);
+        assert_eq!(outcome.cigar().to_string(), "1I1D");
+        Ok(())
+    }
+
+    #[test]
+    fn global_handles_one_empty_input() -> Result<(), Error> {
+        let scoring = Scoring::try_new(2, -3, -2, -1)?;
+        let outcome = global(b"", b"AAA", scoring)?;
+        assert_eq!(outcome.score(), -4);
+        assert_eq!(outcome.cigar().to_string(), "3I");
+        Ok(())
+    }
+
+    #[test]
+    fn global_rejects_two_empty_inputs() -> Result<(), Error> {
+        let scoring = Scoring::try_new(2, -3, -2, -1)?;
+        assert!(matches!(
+            global::<u8>(b"", b"", scoring),
+            Err(Error::EmptyGlobal)
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn global_reports_intermediate_score_overflow() -> Result<(), Error> {
+        let scoring = Scoring::try_new(1, -1, Score::MIN, -1)?;
+        assert!(matches!(
+            global(b"", b"AA", scoring),
+            Err(Error::ScoreOverflow)
+        ));
         Ok(())
     }
 }

--- a/omics-alignment/src/algorithm.rs
+++ b/omics-alignment/src/algorithm.rs
@@ -260,9 +260,6 @@ pub enum Error {
     /// Checked score arithmetic overflowed.
     #[error("alignment score arithmetic overflowed i64")]
     ScoreOverflow,
-    /// A reachable endpoint produced an empty or incomplete traceback.
-    #[error("alignment traceback invariant failed")]
-    TracebackInvariant,
     /// A traceback operation could not be constructed.
     #[error("failed to construct a traceback operation")]
     Operation {

--- a/omics-alignment/src/algorithm/engine.rs
+++ b/omics-alignment/src/algorithm/engine.rs
@@ -165,6 +165,9 @@ fn push_operation(
 fn path_to_cigar(path: &[OperationKind]) -> Result<Cigar, Error> {
     let first = path.first().copied().ok_or(Error::TracebackInvariant)?;
     let mut operations = Vec::new();
+    operations
+        .try_reserve_exact(path.len())
+        .map_err(|source| Error::MatrixAllocation { source })?;
     let mut kind = first;
     let mut run_length = 1usize;
 
@@ -321,7 +324,13 @@ fn compute_global<T: Eq>(reference: &[T], query: &[T], scoring: Scoring) -> Resu
         Error::TracebackInvariant
     })?;
 
+    let max_path_length = reference
+        .len()
+        .checked_add(query.len())
+        .ok_or(Error::MatrixSizeOverflow)?;
     let mut path: Vec<OperationKind> = Vec::new();
+    path.try_reserve_exact(max_path_length)
+        .map_err(|source| Error::MatrixAllocation { source })?;
     let mut i = reference.len();
     let mut j = query.len();
 

--- a/omics-alignment/src/algorithm/engine.rs
+++ b/omics-alignment/src/algorithm/engine.rs
@@ -147,14 +147,18 @@ fn push_operation(
     kind: OperationKind,
     run_length: usize,
 ) -> Result<(), Error> {
-    let length = Number::try_from(run_length).map_err(|_| Error::TracebackInvariant)?;
+    // SAFETY: input lengths are validated against Number before traceback,
+    // and a coalesced run cannot exceed the input length for its axis.
+    let length = Number::try_from(run_length).unwrap();
     operations.push(Operation::try_new(kind, length)?);
     Ok(())
 }
 
 /// Converts a non-empty unit-operation path into a canonical CIGAR.
 fn path_to_cigar(path: &[OperationKind]) -> Result<Cigar, Error> {
-    let first = path.first().copied().ok_or(Error::TracebackInvariant)?;
+    // SAFETY: global alignment rejects two empty inputs, and local alignment
+    // reaches this function only after finding a positive aligned endpoint.
+    let first = path.first().copied().unwrap();
     let mut operations = Vec::new();
     operations
         .try_reserve_exact(path.len())
@@ -194,7 +198,7 @@ pub(super) fn local<T: Eq>(
     compute_local(reference, query, scoring)
 }
 
-/// Validates the input lengths against the active coordinate type.
+/// Validates that traceback run lengths fit the active CIGAR number type.
 fn validate_lengths(reference: usize, query: usize) -> Result<(), Error> {
     Number::try_from(reference).map_err(|_| Error::LengthOutOfRange {
         axis: Axis::Reference,
@@ -372,14 +376,12 @@ fn compute_global<T: Eq>(reference: &[T], query: &[T], scoring: Scoring) -> Resu
         (end_cell.insertion.score, State::Insertion),
     ]);
 
-    let score = endpoint.score.ok_or_else(|| {
-        debug_assert!(false, "global endpoint is unreachable");
-        Error::TracebackInvariant
-    })?;
-    let state = endpoint.predecessor.ok_or_else(|| {
-        debug_assert!(false, "global endpoint has no predecessor");
-        Error::TracebackInvariant
-    })?;
+    // SAFETY: every non-empty global alignment has at least one reachable
+    // terminal state after matrix initialization and recurrence evaluation.
+    let score = endpoint.score.unwrap();
+    // SAFETY: choose assigns a predecessor whenever it selects a reachable
+    // terminal state.
+    let state = endpoint.predecessor.unwrap();
     let (path, reference_start, query_start) = traceback(
         &matrix,
         reference,
@@ -554,6 +556,12 @@ mod tests {
         ])?;
         assert_eq!(cigar.to_string(), "2=1I2X");
         Ok(())
+    }
+
+    #[test]
+    fn empty_traceback_path_panics() {
+        let result = std::panic::catch_unwind(|| path_to_cigar(&[]));
+        assert!(result.is_err());
     }
 
     #[test]

--- a/omics-alignment/src/algorithm/engine.rs
+++ b/omics-alignment/src/algorithm/engine.rs
@@ -147,14 +147,7 @@ fn push_operation(
     kind: OperationKind,
     run_length: usize,
 ) -> Result<(), Error> {
-    let length = Number::try_from(run_length).map_err(|_| Error::LengthOutOfRange {
-        axis: if kind == OperationKind::Insertion {
-            Axis::Query
-        } else {
-            Axis::Reference
-        },
-        length: run_length,
-    })?;
+    let length = Number::try_from(run_length).map_err(|_| Error::TracebackInvariant)?;
     operations.push(Operation::try_new(kind, length)?);
     Ok(())
 }
@@ -221,7 +214,8 @@ fn matrix_dimensions(reference: usize, query: usize) -> Result<(usize, usize), E
     Ok((rows, columns))
 }
 
-/// Recovers the unit-operation path and local start coordinates.
+/// Recovers the unit-operation path and start coordinates reached by walking
+/// backward to an entry without a predecessor.
 fn traceback<T: Eq>(
     matrix: &Matrix,
     reference: &[T],
@@ -471,8 +465,7 @@ fn compute_local<T: Eq>(
             let cell = matrix.get_mut(i, j);
             cell.aligned = match aligned.score {
                 Some(score) if score > 0 => aligned,
-                Some(_) => Entry::RESET,
-                None => Entry::UNREACHABLE,
+                _ => Entry::RESET,
             };
             cell.insertion = insertion;
             cell.deletion = deletion;
@@ -573,9 +566,11 @@ mod tests {
 
     #[test]
     fn matrix_allocation_failure_is_reported() {
-        assert!(matches!(
-            Matrix::try_new(1, usize::MAX),
-            Err(Error::MatrixAllocation { .. })
-        ));
+        let error = match Matrix::try_new(1, usize::MAX) {
+            Err(error) => error,
+            Ok(_) => panic!("expected allocation failure"),
+        };
+        assert!(matches!(error, Error::MatrixAllocation { .. }));
+        assert_eq!(error.to_string(), "failed to allocate alignment storage");
     }
 }

--- a/omics-alignment/src/algorithm/engine.rs
+++ b/omics-alignment/src/algorithm/engine.rs
@@ -1,0 +1,418 @@
+//! Dynamic-programming and traceback implementation.
+
+use omics_coordinate::position::Number;
+
+use crate::cigar::Axis;
+use crate::cigar::Cigar;
+use crate::cigar::Operation;
+use crate::cigar::OperationKind;
+
+use super::Error;
+use super::Outcome;
+use super::Score;
+use super::Scoring;
+
+/// One terminal state in the affine-gap recurrence.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum State {
+    /// Ends by consuming one symbol from each input.
+    Aligned,
+    /// Ends by consuming one query symbol.
+    Insertion,
+    /// Ends by consuming one reference symbol.
+    Deletion,
+}
+
+/// A score and traceback predecessor for one state.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct Entry {
+    /// Score, or `None` when the state is unreachable.
+    score: Option<Score>,
+    /// State at the predecessor coordinate.
+    predecessor: Option<State>,
+}
+
+impl Entry {
+    /// An unreachable state.
+    const UNREACHABLE: Self = Self {
+        score: None,
+        predecessor: None,
+    };
+
+    /// A zero-valued origin or local reset.
+    const RESET: Self = Self {
+        score: Some(0),
+        predecessor: None,
+    };
+
+    /// Constructs a scored state with a predecessor.
+    #[cfg(test)]
+    const fn reachable(score: Score, predecessor: State) -> Self {
+        Self {
+            score: Some(score),
+            predecessor: Some(predecessor),
+        }
+    }
+}
+
+/// The three recurrence states at one matrix coordinate.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct Cell {
+    /// State ending with aligned symbols.
+    aligned: Entry,
+    /// State ending with an insertion.
+    insertion: Entry,
+    /// State ending with a deletion.
+    deletion: Entry,
+}
+
+impl Cell {
+    /// A cell with no reachable states.
+    const UNREACHABLE: Self = Self {
+        aligned: Entry::UNREACHABLE,
+        insertion: Entry::UNREACHABLE,
+        deletion: Entry::UNREACHABLE,
+    };
+
+    /// Returns one state entry.
+    const fn entry(self, state: State) -> Entry {
+        match state {
+            State::Aligned => self.aligned,
+            State::Insertion => self.insertion,
+            State::Deletion => self.deletion,
+        }
+    }
+}
+
+/// Row-major dynamic-programming storage.
+struct Matrix {
+    /// Number of matrix columns.
+    columns: usize,
+    /// Row-major cells.
+    cells: Vec<Cell>,
+}
+
+impl Matrix {
+    /// Allocates an unreachable matrix with checked dimensions.
+    fn try_new(rows: usize, columns: usize) -> Result<Self, Error> {
+        let length = rows.checked_mul(columns).ok_or(Error::MatrixSizeOverflow)?;
+        let mut cells = Vec::new();
+        cells
+            .try_reserve_exact(length)
+            .map_err(|source| Error::MatrixAllocation { source })?;
+        cells.resize(length, Cell::UNREACHABLE);
+        Ok(Self { columns, cells })
+    }
+
+    /// Returns a copied cell.
+    fn get(&self, row: usize, column: usize) -> Cell {
+        self.cells[row * self.columns + column]
+    }
+
+    /// Returns a mutable reference to a cell.
+    fn get_mut(&mut self, row: usize, column: usize) -> &mut Cell {
+        &mut self.cells[row * self.columns + column]
+    }
+}
+
+/// Adds to a reachable score with overflow checking.
+fn checked_add(score: Option<Score>, delta: Score) -> Result<Option<Score>, Error> {
+    score
+        .map(|s| s.checked_add(delta).ok_or(Error::ScoreOverflow))
+        .transpose()
+}
+
+/// Chooses the greatest score and preserves candidate-array order on ties.
+fn choose<const N: usize>(candidates: [(Option<Score>, State); N]) -> Entry {
+    let mut best = Entry::UNREACHABLE;
+
+    for (score, predecessor) in candidates {
+        let replace = match (score, best.score) {
+            (Some(candidate), Some(current)) => candidate > current,
+            (Some(_), None) => true,
+            (None, _) => false,
+        };
+        if replace {
+            best = Entry {
+                score,
+                predecessor: Some(predecessor),
+            };
+        }
+    }
+
+    best
+}
+
+/// Appends one checked, coalesced operation to the accumulator.
+fn push_operation(
+    operations: &mut Vec<Operation>,
+    kind: OperationKind,
+    run_length: usize,
+) -> Result<(), Error> {
+    let length = Number::try_from(run_length).map_err(|_| Error::LengthOutOfRange {
+        axis: if kind == OperationKind::Insertion {
+            Axis::Query
+        } else {
+            Axis::Reference
+        },
+        length: run_length,
+    })?;
+    operations.push(Operation::try_new(kind, length)?);
+    Ok(())
+}
+
+/// Converts a non-empty unit-operation path into a canonical CIGAR.
+fn path_to_cigar(path: &[OperationKind]) -> Result<Cigar, Error> {
+    let first = path.first().copied().ok_or(Error::TracebackInvariant)?;
+    let mut operations = Vec::new();
+    let mut kind = first;
+    let mut run_length = 1usize;
+
+    for next in path.iter().copied().skip(1) {
+        if next == kind {
+            run_length += 1;
+        } else {
+            push_operation(&mut operations, kind, run_length)?;
+            kind = next;
+            run_length = 1;
+        }
+    }
+    push_operation(&mut operations, kind, run_length)?;
+
+    Ok(Cigar::try_new(operations)?)
+}
+
+/// Computes a checked global alignment.
+pub(super) fn global<T: Eq>(
+    reference: &[T],
+    query: &[T],
+    scoring: Scoring,
+) -> Result<Outcome, Error> {
+    compute_global(reference, query, scoring)
+}
+
+/// Drives global matrix initialization, fill, endpoint selection, and traceback.
+fn compute_global<T: Eq>(reference: &[T], query: &[T], scoring: Scoring) -> Result<Outcome, Error> {
+    if reference.is_empty() && query.is_empty() {
+        return Err(Error::EmptyGlobal);
+    }
+
+    Number::try_from(reference.len()).map_err(|_| Error::LengthOutOfRange {
+        axis: Axis::Reference,
+        length: reference.len(),
+    })?;
+    Number::try_from(query.len()).map_err(|_| Error::LengthOutOfRange {
+        axis: Axis::Query,
+        length: query.len(),
+    })?;
+
+    let rows = reference
+        .len()
+        .checked_add(1)
+        .ok_or(Error::MatrixSizeOverflow)?;
+    let columns = query
+        .len()
+        .checked_add(1)
+        .ok_or(Error::MatrixSizeOverflow)?;
+
+    let mut matrix = Matrix::try_new(rows, columns)?;
+
+    matrix.get_mut(0, 0).aligned = Entry::RESET;
+
+    for j in 1..columns {
+        let prev = matrix.get(0, j - 1);
+        let insertion = choose([
+            (
+                checked_add(prev.insertion.score, scoring.gap_extend_score())?,
+                State::Insertion,
+            ),
+            (
+                checked_add(prev.aligned.score, scoring.gap_open_score())?,
+                State::Aligned,
+            ),
+            (
+                checked_add(prev.deletion.score, scoring.gap_open_score())?,
+                State::Deletion,
+            ),
+        ]);
+        matrix.get_mut(0, j).insertion = insertion;
+    }
+
+    for i in 1..rows {
+        let prev = matrix.get(i - 1, 0);
+        let deletion = choose([
+            (
+                checked_add(prev.deletion.score, scoring.gap_extend_score())?,
+                State::Deletion,
+            ),
+            (
+                checked_add(prev.aligned.score, scoring.gap_open_score())?,
+                State::Aligned,
+            ),
+            (
+                checked_add(prev.insertion.score, scoring.gap_open_score())?,
+                State::Insertion,
+            ),
+        ]);
+        matrix.get_mut(i, 0).deletion = deletion;
+    }
+
+    for i in 1..rows {
+        for j in 1..columns {
+            let subst = scoring.substitution(&reference[i - 1], &query[j - 1]);
+            let diag = matrix.get(i - 1, j - 1);
+            let left = matrix.get(i, j - 1);
+            let up = matrix.get(i - 1, j);
+
+            let new_aligned = choose([
+                (checked_add(diag.aligned.score, subst)?, State::Aligned),
+                (checked_add(diag.deletion.score, subst)?, State::Deletion),
+                (checked_add(diag.insertion.score, subst)?, State::Insertion),
+            ]);
+            let new_insertion = choose([
+                (
+                    checked_add(left.insertion.score, scoring.gap_extend_score())?,
+                    State::Insertion,
+                ),
+                (
+                    checked_add(left.aligned.score, scoring.gap_open_score())?,
+                    State::Aligned,
+                ),
+                (
+                    checked_add(left.deletion.score, scoring.gap_open_score())?,
+                    State::Deletion,
+                ),
+            ]);
+            let new_deletion = choose([
+                (
+                    checked_add(up.deletion.score, scoring.gap_extend_score())?,
+                    State::Deletion,
+                ),
+                (
+                    checked_add(up.aligned.score, scoring.gap_open_score())?,
+                    State::Aligned,
+                ),
+                (
+                    checked_add(up.insertion.score, scoring.gap_open_score())?,
+                    State::Insertion,
+                ),
+            ]);
+
+            let cell = matrix.get_mut(i, j);
+            cell.aligned = new_aligned;
+            cell.insertion = new_insertion;
+            cell.deletion = new_deletion;
+        }
+    }
+
+    let end_cell = matrix.get(reference.len(), query.len());
+    let endpoint = choose([
+        (end_cell.aligned.score, State::Aligned),
+        (end_cell.deletion.score, State::Deletion),
+        (end_cell.insertion.score, State::Insertion),
+    ]);
+
+    let score = endpoint.score.ok_or_else(|| {
+        debug_assert!(false, "global endpoint is unreachable");
+        Error::TracebackInvariant
+    })?;
+    let mut state = endpoint.predecessor.ok_or_else(|| {
+        debug_assert!(false, "global endpoint has no predecessor");
+        Error::TracebackInvariant
+    })?;
+
+    let mut path: Vec<OperationKind> = Vec::new();
+    let mut i = reference.len();
+    let mut j = query.len();
+
+    loop {
+        let entry = matrix.get(i, j).entry(state);
+        let Some(predecessor) = entry.predecessor else {
+            break;
+        };
+
+        match state {
+            State::Aligned => {
+                path.push(if reference[i - 1] == query[j - 1] {
+                    OperationKind::SequenceMatch
+                } else {
+                    OperationKind::SequenceMismatch
+                });
+                i -= 1;
+                j -= 1;
+            }
+            State::Insertion => {
+                path.push(OperationKind::Insertion);
+                j -= 1;
+            }
+            State::Deletion => {
+                path.push(OperationKind::Deletion);
+                i -= 1;
+            }
+        }
+
+        state = predecessor;
+    }
+
+    path.reverse();
+    let cigar = path_to_cigar(&path)?;
+    Ok(Outcome::new(
+        score,
+        cigar,
+        0..reference.len(),
+        0..query.len(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn candidate_order_breaks_equal_score_ties() {
+        let entry = choose([
+            (Some(4), State::Aligned),
+            (Some(4), State::Deletion),
+            (Some(4), State::Insertion),
+        ]);
+        assert_eq!(entry, Entry::reachable(4, State::Aligned));
+    }
+
+    #[test]
+    fn checked_score_addition_reports_overflow() {
+        assert!(matches!(
+            checked_add(Some(Score::MAX), 1),
+            Err(Error::ScoreOverflow)
+        ));
+        assert_eq!(checked_add(None, 1).unwrap(), None);
+    }
+
+    #[test]
+    fn traceback_path_coalesces_operations() -> Result<(), Error> {
+        let cigar = path_to_cigar(&[
+            OperationKind::SequenceMatch,
+            OperationKind::SequenceMatch,
+            OperationKind::Insertion,
+            OperationKind::SequenceMismatch,
+            OperationKind::SequenceMismatch,
+        ])?;
+        assert_eq!(cigar.to_string(), "2=1I2X");
+        Ok(())
+    }
+
+    #[test]
+    fn matrix_dimension_overflow_is_reported() {
+        assert!(matches!(
+            Matrix::try_new(usize::MAX, 2),
+            Err(Error::MatrixSizeOverflow)
+        ));
+    }
+
+    #[test]
+    fn matrix_allocation_failure_is_reported() {
+        assert!(matches!(
+            Matrix::try_new(1, usize::MAX),
+            Err(Error::MatrixAllocation { .. })
+        ));
+    }
+}

--- a/omics-alignment/src/algorithm/engine.rs
+++ b/omics-alignment/src/algorithm/engine.rs
@@ -2,15 +2,14 @@
 
 use omics_coordinate::position::Number;
 
-use crate::cigar::Axis;
-use crate::cigar::Cigar;
-use crate::cigar::Operation;
-use crate::cigar::OperationKind;
-
 use super::Error;
 use super::Outcome;
 use super::Score;
 use super::Scoring;
+use crate::cigar::Axis;
+use crate::cigar::Cigar;
+use crate::cigar::Operation;
+use crate::cigar::OperationKind;
 
 /// One terminal state in the affine-gap recurrence.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -33,15 +32,14 @@ struct Entry {
 }
 
 impl Entry {
-    /// An unreachable state.
-    const UNREACHABLE: Self = Self {
-        score: None,
-        predecessor: None,
-    };
-
     /// A zero-valued origin or local reset.
     const RESET: Self = Self {
         score: Some(0),
+        predecessor: None,
+    };
+    /// An unreachable state.
+    const UNREACHABLE: Self = Self {
+        score: None,
         predecessor: None,
     };
 
@@ -194,29 +192,94 @@ pub(super) fn global<T: Eq>(
     compute_global(reference, query, scoring)
 }
 
-/// Drives global matrix initialization, fill, endpoint selection, and traceback.
+/// Computes a checked local alignment.
+pub(super) fn local<T: Eq>(
+    reference: &[T],
+    query: &[T],
+    scoring: Scoring,
+) -> Result<Option<Outcome>, Error> {
+    compute_local(reference, query, scoring)
+}
+
+/// Validates the input lengths against the active coordinate type.
+fn validate_lengths(reference: usize, query: usize) -> Result<(), Error> {
+    Number::try_from(reference).map_err(|_| Error::LengthOutOfRange {
+        axis: Axis::Reference,
+        length: reference,
+    })?;
+    Number::try_from(query).map_err(|_| Error::LengthOutOfRange {
+        axis: Axis::Query,
+        length: query,
+    })?;
+    Ok(())
+}
+
+/// Returns the checked dynamic-programming dimensions.
+fn matrix_dimensions(reference: usize, query: usize) -> Result<(usize, usize), Error> {
+    let rows = reference.checked_add(1).ok_or(Error::MatrixSizeOverflow)?;
+    let columns = query.checked_add(1).ok_or(Error::MatrixSizeOverflow)?;
+    Ok((rows, columns))
+}
+
+/// Recovers the unit-operation path and local start coordinates.
+fn traceback<T: Eq>(
+    matrix: &Matrix,
+    reference: &[T],
+    query: &[T],
+    mut state: State,
+    mut i: usize,
+    mut j: usize,
+) -> Result<(Vec<OperationKind>, usize, usize), Error> {
+    let max_path_length = reference
+        .len()
+        .checked_add(query.len())
+        .ok_or(Error::MatrixSizeOverflow)?;
+    let mut path = Vec::new();
+    path.try_reserve_exact(max_path_length)
+        .map_err(|source| Error::MatrixAllocation { source })?;
+
+    loop {
+        let entry = matrix.get(i, j).entry(state);
+        let Some(predecessor) = entry.predecessor else {
+            break;
+        };
+
+        match state {
+            State::Aligned => {
+                path.push(if reference[i - 1] == query[j - 1] {
+                    OperationKind::SequenceMatch
+                } else {
+                    OperationKind::SequenceMismatch
+                });
+                i -= 1;
+                j -= 1;
+            }
+            State::Insertion => {
+                path.push(OperationKind::Insertion);
+                j -= 1;
+            }
+            State::Deletion => {
+                path.push(OperationKind::Deletion);
+                i -= 1;
+            }
+        }
+
+        state = predecessor;
+    }
+
+    path.reverse();
+    Ok((path, i, j))
+}
+
+/// Drives global matrix initialization, fill, endpoint selection, and
+/// traceback.
 fn compute_global<T: Eq>(reference: &[T], query: &[T], scoring: Scoring) -> Result<Outcome, Error> {
     if reference.is_empty() && query.is_empty() {
         return Err(Error::EmptyGlobal);
     }
 
-    Number::try_from(reference.len()).map_err(|_| Error::LengthOutOfRange {
-        axis: Axis::Reference,
-        length: reference.len(),
-    })?;
-    Number::try_from(query.len()).map_err(|_| Error::LengthOutOfRange {
-        axis: Axis::Query,
-        length: query.len(),
-    })?;
-
-    let rows = reference
-        .len()
-        .checked_add(1)
-        .ok_or(Error::MatrixSizeOverflow)?;
-    let columns = query
-        .len()
-        .checked_add(1)
-        .ok_or(Error::MatrixSizeOverflow)?;
+    validate_lengths(reference.len(), query.len())?;
+    let (rows, columns) = matrix_dimensions(reference.len(), query.len())?;
 
     let mut matrix = Matrix::try_new(rows, columns)?;
 
@@ -319,51 +382,20 @@ fn compute_global<T: Eq>(reference: &[T], query: &[T], scoring: Scoring) -> Resu
         debug_assert!(false, "global endpoint is unreachable");
         Error::TracebackInvariant
     })?;
-    let mut state = endpoint.predecessor.ok_or_else(|| {
+    let state = endpoint.predecessor.ok_or_else(|| {
         debug_assert!(false, "global endpoint has no predecessor");
         Error::TracebackInvariant
     })?;
-
-    let max_path_length = reference
-        .len()
-        .checked_add(query.len())
-        .ok_or(Error::MatrixSizeOverflow)?;
-    let mut path: Vec<OperationKind> = Vec::new();
-    path.try_reserve_exact(max_path_length)
-        .map_err(|source| Error::MatrixAllocation { source })?;
-    let mut i = reference.len();
-    let mut j = query.len();
-
-    loop {
-        let entry = matrix.get(i, j).entry(state);
-        let Some(predecessor) = entry.predecessor else {
-            break;
-        };
-
-        match state {
-            State::Aligned => {
-                path.push(if reference[i - 1] == query[j - 1] {
-                    OperationKind::SequenceMatch
-                } else {
-                    OperationKind::SequenceMismatch
-                });
-                i -= 1;
-                j -= 1;
-            }
-            State::Insertion => {
-                path.push(OperationKind::Insertion);
-                j -= 1;
-            }
-            State::Deletion => {
-                path.push(OperationKind::Deletion);
-                i -= 1;
-            }
-        }
-
-        state = predecessor;
-    }
-
-    path.reverse();
+    let (path, reference_start, query_start) = traceback(
+        &matrix,
+        reference,
+        query,
+        state,
+        reference.len(),
+        query.len(),
+    )?;
+    debug_assert_eq!(reference_start, 0);
+    debug_assert_eq!(query_start, 0);
     let cigar = path_to_cigar(&path)?;
     Ok(Outcome::new(
         score,
@@ -371,6 +403,128 @@ fn compute_global<T: Eq>(reference: &[T], query: &[T], scoring: Scoring) -> Resu
         0..reference.len(),
         0..query.len(),
     ))
+}
+
+/// Drives local matrix initialization, fill, endpoint selection, and traceback.
+fn compute_local<T: Eq>(
+    reference: &[T],
+    query: &[T],
+    scoring: Scoring,
+) -> Result<Option<Outcome>, Error> {
+    if reference.is_empty() || query.is_empty() {
+        return Ok(None);
+    }
+
+    validate_lengths(reference.len(), query.len())?;
+    let (rows, columns) = matrix_dimensions(reference.len(), query.len())?;
+
+    let mut matrix = Matrix::try_new(rows, columns)?;
+
+    for j in 0..columns {
+        matrix.get_mut(0, j).aligned = Entry::RESET;
+    }
+    for i in 1..rows {
+        matrix.get_mut(i, 0).aligned = Entry::RESET;
+    }
+
+    for i in 1..rows {
+        for j in 1..columns {
+            let subst = scoring.substitution(&reference[i - 1], &query[j - 1]);
+            let diag = matrix.get(i - 1, j - 1);
+            let left = matrix.get(i, j - 1);
+            let up = matrix.get(i - 1, j);
+
+            let aligned = choose([
+                (checked_add(diag.aligned.score, subst)?, State::Aligned),
+                (checked_add(diag.deletion.score, subst)?, State::Deletion),
+                (checked_add(diag.insertion.score, subst)?, State::Insertion),
+            ]);
+            let insertion = choose([
+                (
+                    checked_add(left.insertion.score, scoring.gap_extend_score())?,
+                    State::Insertion,
+                ),
+                (
+                    checked_add(left.aligned.score, scoring.gap_open_score())?,
+                    State::Aligned,
+                ),
+                (
+                    checked_add(left.deletion.score, scoring.gap_open_score())?,
+                    State::Deletion,
+                ),
+            ]);
+            let deletion = choose([
+                (
+                    checked_add(up.deletion.score, scoring.gap_extend_score())?,
+                    State::Deletion,
+                ),
+                (
+                    checked_add(up.aligned.score, scoring.gap_open_score())?,
+                    State::Aligned,
+                ),
+                (
+                    checked_add(up.insertion.score, scoring.gap_open_score())?,
+                    State::Insertion,
+                ),
+            ]);
+
+            let cell = matrix.get_mut(i, j);
+            cell.aligned = match aligned.score {
+                Some(score) if score > 0 => aligned,
+                Some(_) => Entry::RESET,
+                None => Entry::UNREACHABLE,
+            };
+            cell.insertion = insertion;
+            cell.deletion = deletion;
+        }
+    }
+
+    let mut endpoint: Option<(Score, usize, usize)> = None;
+    for i in 1..rows {
+        for j in 1..columns {
+            let score = matrix.get(i, j).aligned.score;
+            let Some(score) = score.filter(|score| *score > 0) else {
+                continue;
+            };
+
+            if endpoint
+                .as_ref()
+                .map(|(best, ..)| score > *best)
+                .unwrap_or(true)
+            {
+                endpoint = Some((score, i, j));
+            }
+        }
+    }
+
+    let Some((score, reference_end, query_end)) = endpoint else {
+        return Ok(None);
+    };
+
+    let (path, reference_start, query_start) = traceback(
+        &matrix,
+        reference,
+        query,
+        State::Aligned,
+        reference_end,
+        query_end,
+    )?;
+    debug_assert!(matches!(
+        path.first(),
+        Some(OperationKind::SequenceMatch | OperationKind::SequenceMismatch)
+    ));
+    debug_assert!(matches!(
+        path.last(),
+        Some(OperationKind::SequenceMatch | OperationKind::SequenceMismatch)
+    ));
+    let cigar = path_to_cigar(&path)?;
+
+    Ok(Some(Outcome::new(
+        score,
+        cigar,
+        reference_start..reference_end,
+        query_start..query_end,
+    )))
 }
 
 #[cfg(test)]

--- a/omics-alignment/src/lib.rs
+++ b/omics-alignment/src/lib.rs
@@ -1,9 +1,9 @@
-//! Foundational representations of sequence alignments in the Rust omics
-//! ecosystem.
+//! Foundational representations and algorithms for sequence alignments in the
+//! Rust omics ecosystem.
 //!
-//! This crate provides validated pairwise alignments and lossless
-//! per-operation traversal. It has no dependency on SAM records, BAM, PAF, or
-//! chainfile libraries.
+//! This crate provides validated pairwise alignments, lossless per-operation
+//! traversal, and deterministic global and local affine-gap alignment. It has
+//! no dependency on SAM records, BAM, PAF, or chainfile libraries.
 //!
 //! # Quick start
 //!
@@ -56,11 +56,19 @@
 //!
 //! The [`cigar`] module provides the checked CIGAR model, including
 //! [`cigar::OperationKind`], [`cigar::Operation`], and [`cigar::Cigar`].
+//!
+//! # Algorithms
+//!
+//! The [`algorithm`] module computes deterministic global and local affine-gap
+//! alignments over generic symbol slices. Its [`algorithm::Outcome`] reports a
+//! score, a canonical CIGAR built from `=`, `X`, `I`, and `D`, and half-open
+//! input ranges that place the CIGAR on the original sequences.
 
 pub use alignment::Alignment;
 pub use step::Step;
 
-/// Global and local pairwise sequence-alignment algorithms.
+/// Deterministic global and local affine-gap alignment over generic symbol
+/// slices.
 pub mod algorithm;
 
 /// Validated pairwise alignments with lossless per-operation traversal.

--- a/omics-alignment/src/lib.rs
+++ b/omics-alignment/src/lib.rs
@@ -60,6 +60,9 @@
 pub use alignment::Alignment;
 pub use step::Step;
 
+/// Global and local pairwise sequence-alignment algorithms.
+pub mod algorithm;
+
 /// Validated pairwise alignments with lossless per-operation traversal.
 pub mod alignment;
 

--- a/omics-alignment/tests/algorithm.rs
+++ b/omics-alignment/tests/algorithm.rs
@@ -1,4 +1,5 @@
-//! Exhaustive oracle and public compatibility tests for the alignment algorithms.
+//! Exhaustive oracle and public compatibility tests for the alignment
+//! algorithms.
 
 use omics_alignment::algorithm::Outcome;
 use omics_alignment::algorithm::Score;
@@ -70,7 +71,8 @@ fn score_path<T: Eq>(reference: &[T], query: &[T], path: &[Move], scoring: Scori
     total
 }
 
-/// Recursively enumerates all complete alignment paths, updating the running best.
+/// Recursively enumerates all complete alignment paths, updating the running
+/// best.
 fn enumerate_paths<T: Eq>(
     reference: &[T],
     query: &[T],
@@ -326,8 +328,8 @@ fn exhaustive_local_score_matches_oracle() {
                 } else {
                     let outcome = result.unwrap_or_else(|| {
                         panic!(
-                            "expected Some; ref={reference:?} query={query:?} \
-                             scoring={scoring:?} oracle={expected}"
+                            "expected Some; ref={reference:?} query={query:?} scoring={scoring:?} \
+                             oracle={expected}"
                         )
                     });
                     assert_eq!(
@@ -344,13 +346,13 @@ fn exhaustive_local_score_matches_oracle() {
                     };
                     assert!(
                         is_aligned(first),
-                        "local CIGAR does not start with an aligned op; \
-                         ref={reference:?} query={query:?}"
+                        "local CIGAR does not start with an aligned op; ref={reference:?} \
+                         query={query:?}"
                     );
                     assert!(
                         is_aligned(last),
-                        "local CIGAR does not end with an aligned op; \
-                         ref={reference:?} query={query:?}"
+                        "local CIGAR does not end with an aligned op; ref={reference:?} \
+                         query={query:?}"
                     );
                     assert_outcome_consistent(reference, query, scoring, &outcome);
                 }

--- a/omics-alignment/tests/algorithm.rs
+++ b/omics-alignment/tests/algorithm.rs
@@ -21,10 +21,13 @@ enum Move {
 }
 
 /// Returns the affine gap score for a run of the given length.
+///
+/// Caller must ensure that `length` is at least `1` and that `length - 1`
+/// fits in [`Score`].
 fn gap_score(scoring: Scoring, length: usize) -> Score {
-    // SAFETY: every call site finds a maximal run of length >= 1, so
-    // length - 1 >= 0 and fits in i64 for inputs bounded by 3.
-    scoring.gap_open_score() + Score::try_from(length - 1).unwrap() * scoring.gap_extend_score()
+    // SAFETY: exhaustive callers provide maximal runs from inputs bounded by 3.
+    let extensions = Score::try_from(length - 1).unwrap();
+    scoring.gap_open_score() + extensions * scoring.gap_extend_score()
 }
 
 /// Scores a complete path against the given input slices.

--- a/omics-alignment/tests/algorithm.rs
+++ b/omics-alignment/tests/algorithm.rs
@@ -1,0 +1,360 @@
+//! Exhaustive oracle and public compatibility tests for the alignment algorithms.
+
+use omics_alignment::algorithm::Outcome;
+use omics_alignment::algorithm::Score;
+use omics_alignment::algorithm::Scoring;
+use omics_alignment::algorithm::global;
+use omics_alignment::algorithm::local;
+use omics_alignment::cigar::OperationKind;
+use omics_molecule::polymer::dna::Nucleotide;
+
+/// A move in an exhaustively enumerated alignment path.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Move {
+    /// Aligns one symbol from each input.
+    Aligned,
+    /// Consumes one query symbol without advancing the reference.
+    Insertion,
+    /// Consumes one reference symbol without advancing the query.
+    Deletion,
+}
+
+/// Returns the affine gap score for a run of the given length.
+fn gap_score(scoring: Scoring, length: usize) -> Score {
+    // SAFETY: every call site finds a maximal run of length >= 1, so
+    // length - 1 >= 0 and fits in i64 for inputs bounded by 3.
+    scoring.gap_open_score() + Score::try_from(length - 1).unwrap() * scoring.gap_extend_score()
+}
+
+/// Scores a complete path against the given input slices.
+///
+/// Groups consecutive same-kind gap moves into maximal runs and
+/// applies the affine formula to each run.
+fn score_path<T: Eq>(reference: &[T], query: &[T], path: &[Move], scoring: Scoring) -> Score {
+    let mut ri = 0;
+    let mut qi = 0;
+    let mut total: Score = 0;
+    let mut i = 0;
+    while i < path.len() {
+        match path[i] {
+            Move::Aligned => {
+                total += if reference[ri] == query[qi] {
+                    scoring.match_score()
+                } else {
+                    scoring.mismatch_score()
+                };
+                ri += 1;
+                qi += 1;
+                i += 1;
+            }
+            Move::Insertion => {
+                let start = i;
+                while i < path.len() && path[i] == Move::Insertion {
+                    i += 1;
+                }
+                let run = i - start;
+                total += gap_score(scoring, run);
+                qi += run;
+            }
+            Move::Deletion => {
+                let start = i;
+                while i < path.len() && path[i] == Move::Deletion {
+                    i += 1;
+                }
+                let run = i - start;
+                total += gap_score(scoring, run);
+                ri += run;
+            }
+        }
+    }
+    total
+}
+
+/// Recursively enumerates all complete alignment paths, updating the running best.
+fn enumerate_paths<T: Eq>(
+    reference: &[T],
+    query: &[T],
+    ri: usize,
+    qi: usize,
+    path: &mut Vec<Move>,
+    best: &mut Score,
+    scoring: Scoring,
+) {
+    if ri == reference.len() && qi == query.len() {
+        let s = score_path(reference, query, path, scoring);
+        if s > *best {
+            *best = s;
+        }
+        return;
+    }
+    if ri < reference.len() && qi < query.len() {
+        path.push(Move::Aligned);
+        enumerate_paths(reference, query, ri + 1, qi + 1, path, best, scoring);
+        path.pop();
+    }
+    if qi < query.len() {
+        path.push(Move::Insertion);
+        enumerate_paths(reference, query, ri, qi + 1, path, best, scoring);
+        path.pop();
+    }
+    if ri < reference.len() {
+        path.push(Move::Deletion);
+        enumerate_paths(reference, query, ri + 1, qi, path, best, scoring);
+        path.pop();
+    }
+}
+
+/// Returns the maximum score over all complete global alignment paths.
+fn oracle_global_score<T: Eq>(reference: &[T], query: &[T], scoring: Scoring) -> Score {
+    let mut best = Score::MIN;
+    let mut path = Vec::new();
+    enumerate_paths(reference, query, 0, 0, &mut path, &mut best, scoring);
+    best
+}
+
+/// Enumerates complete paths, retaining only those whose first and last
+/// moves are both Aligned.
+fn enumerate_local_paths<T: Eq>(
+    reference: &[T],
+    query: &[T],
+    ri: usize,
+    qi: usize,
+    path: &mut Vec<Move>,
+    best: &mut Score,
+    scoring: Scoring,
+) {
+    if ri == reference.len() && qi == query.len() {
+        if matches!(path.first(), Some(Move::Aligned)) && matches!(path.last(), Some(Move::Aligned))
+        {
+            let s = score_path(reference, query, path, scoring);
+            if s > *best {
+                *best = s;
+            }
+        }
+        return;
+    }
+    if ri < reference.len() && qi < query.len() {
+        path.push(Move::Aligned);
+        enumerate_local_paths(reference, query, ri + 1, qi + 1, path, best, scoring);
+        path.pop();
+    }
+    if qi < query.len() {
+        path.push(Move::Insertion);
+        enumerate_local_paths(reference, query, ri, qi + 1, path, best, scoring);
+        path.pop();
+    }
+    if ri < reference.len() {
+        path.push(Move::Deletion);
+        enumerate_local_paths(reference, query, ri + 1, qi, path, best, scoring);
+        path.pop();
+    }
+}
+
+/// Returns the maximum local alignment score over every non-empty range pair.
+///
+/// The result is clamped to zero; returns zero when no positive alignment
+/// exists with aligned first and last moves.
+fn oracle_local_score<T: Eq>(reference: &[T], query: &[T], scoring: Scoring) -> Score {
+    let mut best: Score = 0;
+    for rs in 0..reference.len() {
+        for re in (rs + 1)..=reference.len() {
+            for qs in 0..query.len() {
+                for qe in (qs + 1)..=query.len() {
+                    let mut range_best = Score::MIN;
+                    let mut path = Vec::new();
+                    enumerate_local_paths(
+                        &reference[rs..re],
+                        &query[qs..qe],
+                        0,
+                        0,
+                        &mut path,
+                        &mut range_best,
+                        scoring,
+                    );
+                    if range_best > best {
+                        best = range_best;
+                    }
+                }
+            }
+        }
+    }
+    best
+}
+
+/// Returns all binary sequences of length 0 through 3.
+fn all_binary_seqs() -> Vec<Vec<u8>> {
+    let mut seqs = Vec::new();
+    for len in 0usize..=3 {
+        for mask in 0u8..(1u8 << len) {
+            let seq: Vec<u8> = (0..len).map(|i| (mask >> i) & 1).collect();
+            seqs.push(seq);
+        }
+    }
+    seqs
+}
+
+/// Asserts that an outcome's CIGAR is consistent with the inputs and scoring.
+///
+/// Checks symbol equality for matches and mismatches, reconstructs the score
+/// via the affine formula, verifies consumed lengths equal both range lengths,
+/// and verifies no two adjacent operations share a kind.
+fn assert_outcome_consistent<T: Eq + std::fmt::Debug>(
+    reference: &[T],
+    query: &[T],
+    scoring: Scoring,
+    outcome: &Outcome,
+) {
+    let ref_slice = &reference[outcome.reference_range().clone()];
+    let qry_slice = &query[outcome.query_range().clone()];
+    let ops = outcome.cigar().operations();
+
+    for w in ops.windows(2) {
+        assert_ne!(w[0].kind(), w[1].kind(), "adjacent operations share a kind");
+    }
+
+    let mut ri = 0;
+    let mut qi = 0;
+    let mut reconstructed: Score = 0;
+
+    for op in ops {
+        let kind = op.kind();
+        let len = op.length() as usize;
+
+        match kind {
+            OperationKind::SequenceMatch => {
+                for k in 0..len {
+                    assert_eq!(ref_slice[ri + k], qry_slice[qi + k], "= but symbols differ");
+                }
+                reconstructed += len as Score * scoring.match_score();
+                ri += len;
+                qi += len;
+            }
+            OperationKind::SequenceMismatch => {
+                for k in 0..len {
+                    assert_ne!(ref_slice[ri + k], qry_slice[qi + k], "X but symbols match");
+                }
+                reconstructed += len as Score * scoring.mismatch_score();
+                ri += len;
+                qi += len;
+            }
+            OperationKind::Insertion => {
+                reconstructed += gap_score(scoring, len);
+                qi += len;
+            }
+            OperationKind::Deletion => {
+                reconstructed += gap_score(scoring, len);
+                ri += len;
+            }
+            other => panic!("unexpected operation kind {other:?}"),
+        }
+    }
+
+    assert_eq!(ri, ref_slice.len(), "reference consumption mismatch");
+    assert_eq!(qi, qry_slice.len(), "query consumption mismatch");
+    assert_eq!(
+        reconstructed,
+        outcome.score(),
+        "reconstructed score mismatch"
+    );
+}
+
+/// Scoring configurations used across all exhaustive tests.
+fn exhaustive_scorings() -> [Scoring; 4] {
+    [
+        Scoring::try_new(2, -3, -2, -1).unwrap(),
+        Scoring::try_new(1, -5, -1, -1).unwrap(),
+        Scoring::try_new(1, 0, 0, 0).unwrap(),
+        Scoring::try_new(1, -1, 0, -1).unwrap(),
+    ]
+}
+
+#[test]
+fn aligns_byte_slices_through_the_public_api() -> Result<(), Box<dyn std::error::Error>> {
+    let scoring = Scoring::try_new(2, -3, -2, -1)?;
+    assert_eq!(global(b"AC", b"AC", scoring)?.cigar().to_string(), "2=");
+    Ok(())
+}
+
+#[test]
+fn aligns_nucleotide_slices_without_a_production_dependency()
+-> Result<(), Box<dyn std::error::Error>> {
+    let reference = [Nucleotide::A, Nucleotide::C];
+    let query = [Nucleotide::A, Nucleotide::G];
+    let scoring = Scoring::try_new(2, -1, -2, -1)?;
+    assert_eq!(
+        global(&reference, &query, scoring)?.cigar().to_string(),
+        "1=1X"
+    );
+    Ok(())
+}
+
+#[test]
+fn exhaustive_global_score_matches_oracle() {
+    let seqs = all_binary_seqs();
+    for scoring in exhaustive_scorings() {
+        for reference in &seqs {
+            for query in &seqs {
+                if reference.is_empty() && query.is_empty() {
+                    continue;
+                }
+                let expected = oracle_global_score(reference, query, scoring);
+                let outcome = global(reference, query, scoring).expect("global failed");
+                assert_eq!(
+                    outcome.score(),
+                    expected,
+                    "global score mismatch; ref={reference:?} query={query:?} scoring={scoring:?}"
+                );
+                assert_outcome_consistent(reference, query, scoring, &outcome);
+            }
+        }
+    }
+}
+
+#[test]
+fn exhaustive_local_score_matches_oracle() {
+    let seqs = all_binary_seqs();
+    for scoring in exhaustive_scorings() {
+        for reference in &seqs {
+            for query in &seqs {
+                let expected = oracle_local_score(reference, query, scoring);
+                let result = local(reference, query, scoring).expect("local failed");
+                if expected == 0 {
+                    assert!(
+                        result.is_none(),
+                        "expected None; ref={reference:?} query={query:?} scoring={scoring:?}"
+                    );
+                } else {
+                    let outcome = result.unwrap_or_else(|| {
+                        panic!(
+                            "expected Some; ref={reference:?} query={query:?} \
+                             scoring={scoring:?} oracle={expected}"
+                        )
+                    });
+                    assert_eq!(
+                        outcome.score(),
+                        expected,
+                        "local score mismatch; ref={reference:?} query={query:?} \
+                         scoring={scoring:?}"
+                    );
+                    let ops = outcome.cigar().operations();
+                    let first = ops.first().expect("empty CIGAR").kind();
+                    let last = ops.last().expect("empty CIGAR").kind();
+                    let is_aligned = |k: OperationKind| {
+                        k == OperationKind::SequenceMatch || k == OperationKind::SequenceMismatch
+                    };
+                    assert!(
+                        is_aligned(first),
+                        "local CIGAR does not start with an aligned op; \
+                         ref={reference:?} query={query:?}"
+                    );
+                    assert!(
+                        is_aligned(last),
+                        "local CIGAR does not end with an aligned op; \
+                         ref={reference:?} query={query:?}"
+                    );
+                    assert_outcome_consistent(reference, query, scoring, &outcome);
+                }
+            }
+        }
+    }
+}

--- a/omics/CHANGELOG.md
+++ b/omics/CHANGELOG.md
@@ -13,7 +13,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `omics-alignment` as `omics::alignment` and automatically enables the `coordinate`
   component ([#18](https://github.com/stjude-rust-labs/omics/pull/18)).
 * Added the `omics::alignment::algorithm` API under the existing `alignment`
-  feature, including the `global` and `local` affine-gap aligners.
+  feature, including the `global` and `local` affine-gap aligners
+  ([#19](https://github.com/stjude-rust-labs/omics/pull/19)).
 
 ## 0.4.0 - 03-19-2026
 

--- a/omics/CHANGELOG.md
+++ b/omics/CHANGELOG.md
@@ -12,6 +12,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * Added the optional `alignment` component (`--features alignment`), which re-exports
   `omics-alignment` as `omics::alignment` and automatically enables the `coordinate`
   component ([#18](https://github.com/stjude-rust-labs/omics/pull/18)).
+* Added the `omics::alignment::algorithm` API under the existing `alignment`
+  feature, including the `global` and `local` affine-gap aligners.
 
 ## 0.4.0 - 03-19-2026
 

--- a/omics/src/lib.rs
+++ b/omics/src/lib.rs
@@ -10,7 +10,9 @@
 //! ## Alignment
 //!
 //! Enable the `alignment` feature to access validated pairwise sequence
-//! traversal. The feature automatically enables `coordinate`.
+//! traversal and deterministic affine-gap alignment. The feature automatically
+//! enables `coordinate`. It re-exports
+//! `omics::alignment::algorithm::{global, local}` for generic symbol slices.
 //!
 //! ```
 //! # #[cfg(feature = "alignment")]

--- a/omics/src/lib.rs
+++ b/omics/src/lib.rs
@@ -11,8 +11,8 @@
 //!
 //! Enable the `alignment` feature to access validated pairwise sequence
 //! traversal and deterministic affine-gap alignment. The feature automatically
-//! enables `coordinate`. It re-exports
-//! `omics::alignment::algorithm::{global, local}` for generic symbol slices.
+//! enables `coordinate`. It makes `omics::alignment::algorithm::{global,
+//! local}` available for generic symbol slices.
 //!
 //! ```
 //! # #[cfg(feature = "alignment")]


### PR DESCRIPTION
`omics-alignment` represented validated alignment traversals but could not compute an alignment from two sequences. This added generic global and local affine-gap alignment with explicit scoring, deterministic traceback, canonical `=`, `X`, `I`, and `D` CIGAR output, and input ranges for placing local results.

The implementation used checked `i64` arithmetic and fallible unbanded Gotoh matrices, and an independent exhaustive oracle verified optimality and CIGAR consistency across short sequences and edge-case scoring. The first release intentionally returned one deterministic optimum and deferred banding, SIMD, substitution matrices, and semi-global modes.

Before submitting this PR, please make sure:

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
