### PR TITLE
feat: add copy-number variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,12 @@ following features are included and are top-level goals of the project.
   relevant in omics including smaller compounds (e.g., nucleotides) and larger
   polymers (e.g., DNA, RNA).
 - **Variation (`omics::variation`).** Facilities for expressing small sequence
-  variants, strandless copy-number variants over half-open regions, and
-  adjacency-defined structural variants. Small variants include single
-  nucleotide variants (SNVs), multi-nucleotide variants (MNVs), insertions,
-  deletions, and deletion-insertions (delins).
+  variants, strandless copy-number variants over half-open regions with typed
+  absolute counts and typed ploidy baselines, and adjacency-defined structural
+  variants. Base-2 and base-10 count conversions require a nonzero typed
+  ploidy and reject ratios that do not reconstruct an integral absolute count.
+  Small variants include single nucleotide variants (SNVs), multi-nucleotide
+  variants (MNVs), insertions, deletions, and deletion-insertions (delins).
 
 ## 🖥️ Development
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ following features are included and are top-level goals of the project.
   relevant in omics including smaller compounds (e.g., nucleotides) and larger
   polymers (e.g., DNA, RNA).
 - **Variation (`omics::variation`).** Facilities for expressing small sequence
-  variants, including single nucleotide variants (SNVs), multi-nucleotide
-  variants (MNVs), insertions, deletions, and deletion-insertions (delins).
+  variants, strandless copy-number variants over half-open regions, and
+  adjacency-defined structural variants. Small variants include single
+  nucleotide variants (SNVs), multi-nucleotide variants (MNVs), insertions,
+  deletions, and deletion-insertions (delins).
 
 ## 🖥️ Development
 

--- a/README.md
+++ b/README.md
@@ -64,11 +64,13 @@ following features are included and are top-level goals of the project.
   polymers (e.g., DNA, RNA).
 - **Variation (`omics::variation`).** Facilities for expressing small sequence
   variants, strandless copy-number variants over half-open regions with typed
-  absolute counts and typed ploidy baselines, and adjacency-defined structural
-  variants. Base-2 and base-10 count conversions require a nonzero typed
-  ploidy and reject ratios that do not reconstruct an integral absolute count.
-  Small variants include single nucleotide variants (SNVs), multi-nucleotide
-  variants (MNVs), insertions, deletions, and deletion-insertions (delins).
+  absolute counts and required reference ploidy as part of variant identity,
+  and adjacency-defined structural variants. Copy-number canonical strings use
+  `copies/ploidy`. Base-2 and base-10 count and variant conversions require a
+  nonzero typed ploidy and reject ratios that do not reconstruct an integral
+  absolute count. Small variants include single nucleotide variants (SNVs),
+  multi-nucleotide variants (MNVs), insertions, deletions, and
+  deletion-insertions (delins).
 
 ## 🖥️ Development
 

--- a/omics-variation/CHANGELOG.md
+++ b/omics-variation/CHANGELOG.md
@@ -31,6 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or complex) is derived from breakend geometry rather than stored. The tier
   parses and serializes a compact crate-local string format and ships Criterion
   benchmarks ([#16](https://github.com/stjude-rust-labs/omics/pull/16)).
+* Added a copy-number tier with strandless half-open regions, typed absolute
+  `Count` observations, nonzero `Ploidy` baselines, canonical
+  `contig:start-end(i):copies` serialization, baseline-relative `Change`
+  classification, strict base-2 and base-10 logarithmic conversions, and
+  top-level `CopyNumber*` aliases.
 
 ### Changed
 

--- a/omics-variation/CHANGELOG.md
+++ b/omics-variation/CHANGELOG.md
@@ -32,10 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parses and serializes a compact crate-local string format and ships Criterion
   benchmarks ([#16](https://github.com/stjude-rust-labs/omics/pull/16)).
 * Added a copy-number tier with strandless half-open regions, typed absolute
-  `Count` observations, nonzero `Ploidy` baselines, canonical
-  `contig:start-end(i):copies` serialization, baseline-relative `Change`
-  classification, strict base-2 and base-10 logarithmic conversions, and
-  top-level `CopyNumber*` aliases.
+  `Count` observations, required reference `Ploidy` on every `Variant`,
+  canonical `contig:start-end(i):copies/ploidy` serialization,
+  reference-relative `Change` classification, strict base-2 and base-10
+  logarithmic conversions, and top-level `CopyNumber*` aliases.
 
 ### Changed
 
@@ -63,6 +63,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   coordinates or `(i)` for interbase coordinates. `SNV`, `MNV`, deletion, and
   delins records accept only `(b)`, while insertion records accept only `(i)`
   ([#15](https://github.com/stjude-rust-labs/omics/pull/15)).
+* **Breaking:** copy-number `Variant` constructors now require a reference
+  `Ploidy`, copy-number `Variant` identity now includes that ploidy, and
+  canonical copy-number strings now serialize as `contig:start-end(i):copies/ploidy`.
+* **Breaking:** copy-number `Variant::change`, `Variant::log2`, and
+  `Variant::log10` now use the stored reference ploidy without arguments, and
+  `Change::Baseline` is renamed to `Change::Reference`.
 
 ### Crate Updates
 

--- a/omics-variation/Cargo.toml
+++ b/omics-variation/Cargo.toml
@@ -32,3 +32,7 @@ harness = false
 [[bench]]
 name = "structural"
 harness = false
+
+[[bench]]
+name = "copy_number"
+harness = false

--- a/omics-variation/benches/copy_number.rs
+++ b/omics-variation/benches/copy_number.rs
@@ -14,13 +14,10 @@ use omics_variation::CopyNumberPloidy;
 use omics_variation::CopyNumberVariant;
 
 /// A canonical copy-number variant fixture.
-const VARIANT: &str = "seq0:100-200(i):3";
+const VARIANT: &str = "seq0:100-200(i):3/2";
 
 /// The observed copy count used by the logarithmic benchmarks.
 const COUNT: CopyNumberCount = CopyNumberCount::new(3);
-
-/// The baseline count used by the change benchmark.
-const BASELINE: CopyNumberCount = CopyNumberCount::new(2);
 
 /// Constructs the canonical copy-number fixture.
 fn construct_variant() -> CopyNumberVariant {
@@ -29,6 +26,7 @@ fn construct_variant() -> CopyNumberVariant {
         black_box(100),
         black_box(200),
         black_box(3),
+        black_box(CopyNumberPloidy::DIPLOID),
     ) {
         Ok(variant) => variant,
         Err(err) => panic!("benchmark fixture failed to construct; {err}"),
@@ -48,9 +46,9 @@ fn display_variant(variant: &CopyNumberVariant) -> String {
     black_box(variant).to_string()
 }
 
-/// Classifies a copy-number variant against the baseline count.
+/// Classifies a copy-number variant against its stored ploidy.
 fn classify_change(variant: &CopyNumberVariant) -> omics_variation::CopyNumberChange {
-    black_box(variant).change(black_box(BASELINE))
+    black_box(variant).change()
 }
 
 /// Converts an absolute count into a base-2 logarithmic ratio.

--- a/omics-variation/benches/copy_number.rs
+++ b/omics-variation/benches/copy_number.rs
@@ -36,7 +36,8 @@ fn construct_variant() -> CopyNumberVariant {
     }
 }
 
-/// Constructs the canonical copy-number fixture from a base-2 logarithmic ratio.
+/// Constructs the canonical copy-number fixture from a base-2 logarithmic
+/// ratio.
 fn construct_variant_from_log2(
     value: f64,
 ) -> Result<CopyNumberVariant, omics_variation::copy_number::LogarithmicVariantError> {
@@ -49,7 +50,8 @@ fn construct_variant_from_log2(
     )
 }
 
-/// Constructs the canonical copy-number fixture from a base-10 logarithmic ratio.
+/// Constructs the canonical copy-number fixture from a base-10 logarithmic
+/// ratio.
 fn construct_variant_from_log10(
     value: f64,
 ) -> Result<CopyNumberVariant, omics_variation::copy_number::LogarithmicVariantError> {

--- a/omics-variation/benches/copy_number.rs
+++ b/omics-variation/benches/copy_number.rs
@@ -1,0 +1,137 @@
+//! Benchmarks for copy-number variants.
+#![expect(
+    missing_docs,
+    reason = "criterion_group generates undocumented registration functions"
+)]
+
+use std::hint::black_box;
+
+use criterion::Criterion;
+use criterion::criterion_group;
+use criterion::criterion_main;
+use omics_variation::CopyNumberCount;
+use omics_variation::CopyNumberPloidy;
+use omics_variation::CopyNumberVariant;
+
+/// A canonical copy-number variant fixture.
+const VARIANT: &str = "seq0:100-200(i):3";
+
+/// The observed copy count used by the logarithmic benchmarks.
+const COUNT: CopyNumberCount = CopyNumberCount::new(3);
+
+/// The baseline count used by the change benchmark.
+const BASELINE: CopyNumberCount = CopyNumberCount::new(2);
+
+/// Constructs the canonical copy-number fixture.
+fn construct_variant() -> CopyNumberVariant {
+    match CopyNumberVariant::try_new(
+        black_box("seq0"),
+        black_box(100),
+        black_box(200),
+        black_box(3),
+    ) {
+        Ok(variant) => variant,
+        Err(err) => panic!("benchmark fixture failed to construct; {err}"),
+    }
+}
+
+/// Parses the canonical copy-number fixture.
+fn parse_variant(input: &str) -> CopyNumberVariant {
+    match input.parse() {
+        Ok(variant) => variant,
+        Err(err) => panic!("benchmark fixture failed to parse; {err}"),
+    }
+}
+
+/// Displays a copy-number variant.
+fn display_variant(variant: &CopyNumberVariant) -> String {
+    black_box(variant).to_string()
+}
+
+/// Classifies a copy-number variant against the baseline count.
+fn classify_change(variant: &CopyNumberVariant) -> omics_variation::CopyNumberChange {
+    black_box(variant).change(black_box(BASELINE))
+}
+
+/// Converts an absolute count into a base-2 logarithmic ratio.
+fn to_log2(count: CopyNumberCount) -> f64 {
+    black_box(count).log2(CopyNumberPloidy::DIPLOID)
+}
+
+/// Converts an absolute count into a base-10 logarithmic ratio.
+fn to_log10(count: CopyNumberCount) -> f64 {
+    black_box(count).log10(CopyNumberPloidy::DIPLOID)
+}
+
+/// Converts a base-2 logarithmic ratio into an absolute count.
+fn from_log2(
+    value: f64,
+) -> Result<CopyNumberCount, omics_variation::copy_number::LogarithmicError> {
+    CopyNumberCount::try_from_log2(black_box(value), CopyNumberPloidy::DIPLOID)
+}
+
+/// Converts a base-10 logarithmic ratio into an absolute count.
+fn from_log10(
+    value: f64,
+) -> Result<CopyNumberCount, omics_variation::copy_number::LogarithmicError> {
+    CopyNumberCount::try_from_log10(black_box(value), CopyNumberPloidy::DIPLOID)
+}
+
+/// Registers copy-number construction benchmarks.
+fn construct_benches(c: &mut Criterion) {
+    c.bench_function("copy_number::construct::variant", |b| {
+        b.iter(construct_variant)
+    });
+}
+
+/// Registers copy-number parsing benchmarks.
+fn parse_benches(c: &mut Criterion) {
+    c.bench_function("copy_number::parse::canonical", |b| {
+        b.iter(|| parse_variant(black_box(VARIANT)))
+    });
+}
+
+/// Registers copy-number display benchmarks.
+fn display_benches(c: &mut Criterion) {
+    let variant = parse_variant(VARIANT);
+
+    c.bench_function("copy_number::display::canonical", |b| {
+        b.iter(|| display_variant(&variant))
+    });
+}
+
+/// Registers copy-number change benchmarks.
+fn change_benches(c: &mut Criterion) {
+    let variant = parse_variant(VARIANT);
+
+    c.bench_function("copy_number::change::classify", |b| {
+        b.iter(|| classify_change(&variant))
+    });
+}
+
+/// Registers copy-number logarithmic conversion benchmarks.
+fn logarithmic_benches(c: &mut Criterion) {
+    let log2 = to_log2(COUNT);
+    let log10 = to_log10(COUNT);
+
+    c.bench_function("copy_number::count::to_log2", |b| b.iter(|| to_log2(COUNT)));
+    c.bench_function("copy_number::count::to_log10", |b| {
+        b.iter(|| to_log10(COUNT))
+    });
+    c.bench_function("copy_number::count::from_log2", |b| {
+        b.iter(|| from_log2(black_box(log2)))
+    });
+    c.bench_function("copy_number::count::from_log10", |b| {
+        b.iter(|| from_log10(black_box(log10)))
+    });
+}
+
+criterion_group!(
+    benches,
+    construct_benches,
+    parse_benches,
+    display_benches,
+    change_benches,
+    logarithmic_benches,
+);
+criterion_main!(benches);

--- a/omics-variation/benches/copy_number.rs
+++ b/omics-variation/benches/copy_number.rs
@@ -19,6 +19,9 @@ const VARIANT: &str = "seq0:100-200(i):3/2";
 /// The observed copy count used by the logarithmic benchmarks.
 const COUNT: CopyNumberCount = CopyNumberCount::new(3);
 
+/// The reference ploidy used by the variant benchmarks.
+const PLOIDY: CopyNumberPloidy = CopyNumberPloidy::DIPLOID;
+
 /// Constructs the canonical copy-number fixture.
 fn construct_variant() -> CopyNumberVariant {
     match CopyNumberVariant::try_new(
@@ -26,11 +29,37 @@ fn construct_variant() -> CopyNumberVariant {
         black_box(100),
         black_box(200),
         black_box(3),
-        black_box(CopyNumberPloidy::DIPLOID),
+        black_box(PLOIDY),
     ) {
         Ok(variant) => variant,
         Err(err) => panic!("benchmark fixture failed to construct; {err}"),
     }
+}
+
+/// Constructs the canonical copy-number fixture from a base-2 logarithmic ratio.
+fn construct_variant_from_log2(
+    value: f64,
+) -> Result<CopyNumberVariant, omics_variation::copy_number::LogarithmicVariantError> {
+    CopyNumberVariant::try_from_log2(
+        black_box("seq0"),
+        black_box(100),
+        black_box(200),
+        black_box(value),
+        black_box(PLOIDY),
+    )
+}
+
+/// Constructs the canonical copy-number fixture from a base-10 logarithmic ratio.
+fn construct_variant_from_log10(
+    value: f64,
+) -> Result<CopyNumberVariant, omics_variation::copy_number::LogarithmicVariantError> {
+    CopyNumberVariant::try_from_log10(
+        black_box("seq0"),
+        black_box(100),
+        black_box(200),
+        black_box(value),
+        black_box(PLOIDY),
+    )
 }
 
 /// Parses the canonical copy-number fixture.
@@ -51,34 +80,53 @@ fn classify_change(variant: &CopyNumberVariant) -> omics_variation::CopyNumberCh
     black_box(variant).change()
 }
 
+/// Gets the base-2 logarithmic ratio from a copy-number variant.
+fn variant_log2(variant: &CopyNumberVariant) -> f64 {
+    black_box(variant).log2()
+}
+
+/// Gets the base-10 logarithmic ratio from a copy-number variant.
+fn variant_log10(variant: &CopyNumberVariant) -> f64 {
+    black_box(variant).log10()
+}
+
 /// Converts an absolute count into a base-2 logarithmic ratio.
 fn to_log2(count: CopyNumberCount) -> f64 {
-    black_box(count).log2(CopyNumberPloidy::DIPLOID)
+    black_box(count).log2(PLOIDY)
 }
 
 /// Converts an absolute count into a base-10 logarithmic ratio.
 fn to_log10(count: CopyNumberCount) -> f64 {
-    black_box(count).log10(CopyNumberPloidy::DIPLOID)
+    black_box(count).log10(PLOIDY)
 }
 
 /// Converts a base-2 logarithmic ratio into an absolute count.
 fn from_log2(
     value: f64,
 ) -> Result<CopyNumberCount, omics_variation::copy_number::LogarithmicError> {
-    CopyNumberCount::try_from_log2(black_box(value), CopyNumberPloidy::DIPLOID)
+    CopyNumberCount::try_from_log2(black_box(value), PLOIDY)
 }
 
 /// Converts a base-10 logarithmic ratio into an absolute count.
 fn from_log10(
     value: f64,
 ) -> Result<CopyNumberCount, omics_variation::copy_number::LogarithmicError> {
-    CopyNumberCount::try_from_log10(black_box(value), CopyNumberPloidy::DIPLOID)
+    CopyNumberCount::try_from_log10(black_box(value), PLOIDY)
 }
 
 /// Registers copy-number construction benchmarks.
 fn construct_benches(c: &mut Criterion) {
+    let log2 = to_log2(COUNT);
+    let log10 = to_log10(COUNT);
+
     c.bench_function("copy_number::construct::variant", |b| {
         b.iter(construct_variant)
+    });
+    c.bench_function("copy_number::construct::variant_from_log2", |b| {
+        b.iter(|| construct_variant_from_log2(black_box(log2)))
+    });
+    c.bench_function("copy_number::construct::variant_from_log10", |b| {
+        b.iter(|| construct_variant_from_log10(black_box(log10)))
     });
 }
 
@@ -104,6 +152,12 @@ fn change_benches(c: &mut Criterion) {
 
     c.bench_function("copy_number::change::classify", |b| {
         b.iter(|| classify_change(&variant))
+    });
+    c.bench_function("copy_number::variant::log2", |b| {
+        b.iter(|| variant_log2(&variant))
+    });
+    c.bench_function("copy_number::variant::log10", |b| {
+        b.iter(|| variant_log10(&variant))
     });
 }
 

--- a/omics-variation/src/copy_number.rs
+++ b/omics-variation/src/copy_number.rs
@@ -90,6 +90,10 @@ impl Count {
         }
 
         let rounded = copies.round();
+        if rounded == 0.0 {
+            return Err(LogarithmicError::Underflow);
+        }
+
         let tolerance = 8.0 * f64::EPSILON * copies.abs().max(1.0);
         if (copies - rounded).abs() > tolerance {
             return Err(LogarithmicError::NonIntegral);

--- a/omics-variation/src/copy_number.rs
+++ b/omics-variation/src/copy_number.rs
@@ -207,7 +207,7 @@ pub enum Error {
 /// An error related to parsing a copy-number variant.
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum ParseError {
-    /// The variant did not have the three colon-separated fields.
+    /// The variant did not match the canonical copy-number form.
     #[error("invalid copy-number format: `{0}`")]
     Format(String),
 
@@ -239,6 +239,17 @@ pub enum ParseError {
         /// The offending count token.
         copies: String,
     },
+
+    /// The ploidy failed to parse as a positive integer.
+    #[error("invalid copy-number ploidy: `{ploidy}`")]
+    Ploidy {
+        /// The offending ploidy token.
+        ploidy: String,
+    },
+
+    /// The ploidy was zero.
+    #[error("copy-number ploidy cannot be zero")]
+    ZeroPloidy,
 
     /// The region has no span.
     #[error("copy-number region cannot be empty")]
@@ -349,12 +360,20 @@ impl FromStr for Variant {
     type Err = ParseError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        let Some((contig_and_range, copies)) = value.rsplit_once(VARIANT_SEPARATOR) else {
+        let Some((contig_and_range, copies_and_ploidy)) = value.rsplit_once(VARIANT_SEPARATOR)
+        else {
             return Err(ParseError::Format(value.to_string()));
         };
         let Some((contig, range)) = contig_and_range.rsplit_once(VARIANT_SEPARATOR) else {
             return Err(ParseError::Format(value.to_string()));
         };
+        let Some((copies, ploidy)) = copies_and_ploidy.split_once('/') else {
+            return Err(ParseError::Format(value.to_string()));
+        };
+
+        if copies.is_empty() || ploidy.is_empty() || ploidy.contains('/') {
+            return Err(ParseError::Format(value.to_string()));
+        }
 
         let range = range
             .strip_suffix("(i)")
@@ -377,13 +396,17 @@ impl FromStr for Variant {
         let copies = copies.parse::<u32>().map_err(|_| ParseError::Copies {
             copies: copies.to_string(),
         })?;
+        let ploidy = ploidy.parse::<u32>().map_err(|_| ParseError::Ploidy {
+            ploidy: ploidy.to_string(),
+        })?;
+        let ploidy = Ploidy::try_new(ploidy).map_err(|_| ParseError::ZeroPloidy)?;
 
         Ok(Variant::try_new(
             contig,
             start.get(),
             end.get(),
             copies,
-            Ploidy::DIPLOID,
+            ploidy,
         )?)
     }
 }
@@ -392,11 +415,12 @@ impl fmt::Display for Variant {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             formatter,
-            "{contig}{sep}{start}-{end}(i){sep}{copies}",
+            "{contig}{sep}{start}-{end}(i){sep}{copies}/{ploidy}",
             contig = self.contig,
             start = self.start.get(),
             end = self.end.get(),
             copies = self.count.get(),
+            ploidy = self.ploidy.get(),
             sep = VARIANT_SEPARATOR,
         )
     }

--- a/omics-variation/src/copy_number.rs
+++ b/omics-variation/src/copy_number.rs
@@ -14,14 +14,14 @@ use omics_coordinate::system::Interbase;
 use omics_core::VARIANT_SEPARATOR;
 use thiserror::Error;
 
-/// The copy-number change relative to a baseline.
+/// The copy-number change relative to the reference ploidy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Change {
-    /// The observed copy number is below baseline.
+    /// The observed copy number is below the reference ploidy.
     Loss,
-    /// The observed copy number matches baseline.
-    Baseline,
-    /// The observed copy number is above baseline.
+    /// The observed copy number matches the reference ploidy.
+    Reference,
+    /// The observed copy number is above the reference ploidy.
     Gain,
 }
 
@@ -270,6 +270,8 @@ pub struct Variant {
     end: Position<Interbase>,
     /// The observed copy count over the interval.
     count: Count,
+    /// The reference ploidy for the interval.
+    ploidy: Ploidy,
 }
 
 impl Variant {
@@ -279,6 +281,7 @@ impl Variant {
         start: Number,
         end: Number,
         copies: u32,
+        ploidy: Ploidy,
     ) -> Result<Self, Error> {
         let contig = contig.try_into()?;
 
@@ -293,6 +296,7 @@ impl Variant {
             start: InterbasePosition::new(start),
             end: InterbasePosition::new(end),
             count: Count::new(copies),
+            ploidy,
         })
     }
 
@@ -316,13 +320,28 @@ impl Variant {
         self.count
     }
 
-    /// Classifies the variant against a baseline copy number.
-    pub fn change(&self, baseline: Count) -> Change {
-        match self.count.cmp(&baseline) {
+    /// Gets the reference ploidy.
+    pub fn ploidy(&self) -> Ploidy {
+        self.ploidy
+    }
+
+    /// Classifies the variant against its stored reference ploidy.
+    pub fn change(&self) -> Change {
+        match self.count.get().cmp(&self.ploidy.get()) {
             Ordering::Less => Change::Loss,
-            Ordering::Equal => Change::Baseline,
+            Ordering::Equal => Change::Reference,
             Ordering::Greater => Change::Gain,
         }
+    }
+
+    /// Gets the base-2 logarithmic ratio relative to the reference ploidy.
+    pub fn log2(&self) -> f64 {
+        self.count.log2(self.ploidy)
+    }
+
+    /// Gets the base-10 logarithmic ratio relative to the reference ploidy.
+    pub fn log10(&self) -> f64 {
+        self.count.log10(self.ploidy)
     }
 }
 
@@ -359,7 +378,13 @@ impl FromStr for Variant {
             copies: copies.to_string(),
         })?;
 
-        Ok(Variant::try_new(contig, start.get(), end.get(), copies)?)
+        Ok(Variant::try_new(
+            contig,
+            start.get(),
+            end.get(),
+            copies,
+            Ploidy::DIPLOID,
+        )?)
     }
 }
 

--- a/omics-variation/src/copy_number.rs
+++ b/omics-variation/src/copy_number.rs
@@ -330,15 +330,17 @@ impl FromStr for Variant {
     type Err = ParseError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        let parts = value.split(VARIANT_SEPARATOR).collect::<Vec<_>>();
-        let [contig, range, copies] = parts.as_slice() else {
+        let Some((contig_and_range, copies)) = value.rsplit_once(VARIANT_SEPARATOR) else {
+            return Err(ParseError::Format(value.to_string()));
+        };
+        let Some((contig, range)) = contig_and_range.rsplit_once(VARIANT_SEPARATOR) else {
             return Err(ParseError::Format(value.to_string()));
         };
 
         let range = range
             .strip_suffix("(i)")
             .ok_or_else(|| ParseError::Qualifier {
-                region: (*range).to_string(),
+                region: range.to_string(),
             })?;
 
         let (start, end) = range.split_once('-').ok_or_else(|| ParseError::Range {
@@ -354,10 +356,10 @@ impl FromStr for Variant {
         let start = start.parse::<InterbasePosition>()?;
         let end = end.parse::<InterbasePosition>()?;
         let copies = copies.parse::<u32>().map_err(|_| ParseError::Copies {
-            copies: (*copies).to_string(),
+            copies: copies.to_string(),
         })?;
 
-        Ok(Variant::try_new(*contig, start.get(), end.get(), copies)?)
+        Ok(Variant::try_new(contig, start.get(), end.get(), copies)?)
     }
 }
 

--- a/omics-variation/src/copy_number.rs
+++ b/omics-variation/src/copy_number.rs
@@ -2,6 +2,7 @@
 
 use std::cmp::Ordering;
 use std::fmt;
+use std::num::NonZeroU32;
 use std::str::FromStr;
 
 use omics_coordinate::Contig;
@@ -22,6 +23,160 @@ pub enum Change {
     Baseline,
     /// The observed copy number is above baseline.
     Gain,
+}
+
+/// An absolute copy count.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Count(u32);
+
+impl Count {
+    /// Creates a copy count from a raw integer value.
+    pub const fn new(count: u32) -> Self {
+        Self(count)
+    }
+
+    /// Gets the raw copy count.
+    pub const fn get(self) -> u32 {
+        self.0
+    }
+
+    /// Attempts to construct a count from a base-2 logarithmic ratio.
+    pub fn try_from_log2(value: f64, ploidy: Ploidy) -> Result<Self, LogarithmicError> {
+        Self::try_from_logarithmic(value, ploidy, LogarithmicBase::Two)
+    }
+
+    /// Attempts to construct a count from a base-10 logarithmic ratio.
+    pub fn try_from_log10(value: f64, ploidy: Ploidy) -> Result<Self, LogarithmicError> {
+        Self::try_from_logarithmic(value, ploidy, LogarithmicBase::Ten)
+    }
+
+    /// Gets the base-2 logarithmic ratio relative to the ploidy baseline.
+    pub fn log2(self, ploidy: Ploidy) -> f64 {
+        let ratio = f64::from(self.get()) / f64::from(ploidy.get());
+        ratio.log2()
+    }
+
+    /// Gets the base-10 logarithmic ratio relative to the ploidy baseline.
+    pub fn log10(self, ploidy: Ploidy) -> f64 {
+        let ratio = f64::from(self.get()) / f64::from(ploidy.get());
+        ratio.log10()
+    }
+
+    fn try_from_logarithmic(
+        value: f64,
+        ploidy: Ploidy,
+        base: LogarithmicBase,
+    ) -> Result<Self, LogarithmicError> {
+        if value.is_nan() {
+            return Err(LogarithmicError::NotANumber);
+        }
+
+        if value == f64::NEG_INFINITY {
+            return Ok(Self::new(0));
+        }
+
+        if value == f64::INFINITY {
+            return Err(LogarithmicError::PositiveInfinity);
+        }
+
+        let copies = f64::from(ploidy.get()) * base.powf(value);
+
+        if copies == 0.0 {
+            return Err(LogarithmicError::Underflow);
+        }
+
+        if copies > f64::from(u32::MAX) {
+            return Err(LogarithmicError::Overflow);
+        }
+
+        let rounded = copies.round();
+        let tolerance = 8.0 * f64::EPSILON * copies.abs().max(1.0);
+        if (copies - rounded).abs() > tolerance {
+            return Err(LogarithmicError::NonIntegral);
+        }
+
+        Ok(Self::new(rounded as u32))
+    }
+}
+
+/// A positive baseline ploidy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Ploidy(NonZeroU32);
+
+impl Ploidy {
+    /// The diploid baseline.
+    // SAFETY: `2` is nonzero.
+    pub const DIPLOID: Self = Self(unsafe { NonZeroU32::new_unchecked(2) });
+    /// The haploid baseline.
+    pub const HAPLOID: Self = Self(NonZeroU32::MIN);
+
+    /// Attempts to create a ploidy from a raw integer value.
+    pub const fn try_new(value: u32) -> Result<Self, PloidyError> {
+        match NonZeroU32::new(value) {
+            Some(value) => Ok(Self(value)),
+            None => Err(PloidyError::Zero),
+        }
+    }
+
+    /// Gets the raw ploidy value.
+    pub const fn get(self) -> u32 {
+        self.0.get()
+    }
+}
+
+/// An error related to ploidy construction.
+#[derive(Error, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PloidyError {
+    /// The ploidy was zero.
+    #[error("ploidy cannot be zero")]
+    Zero,
+}
+
+impl TryFrom<u32> for Ploidy {
+    type Error = PloidyError;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        Self::try_new(value)
+    }
+}
+
+/// An error related to logarithmic conversion.
+#[derive(Error, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogarithmicError {
+    /// The logarithmic value was not a number.
+    #[error("logarithmic copy-number value cannot be `nan`")]
+    NotANumber,
+
+    /// The logarithmic value was positive infinity.
+    #[error("logarithmic copy-number value cannot be positive infinity")]
+    PositiveInfinity,
+
+    /// The logarithmic value underflowed below one copy.
+    #[error("logarithmic copy-number value underflowed below one copy")]
+    Underflow,
+
+    /// The logarithmic value overflowed the supported count range.
+    #[error("logarithmic copy-number value overflowed the `u32` count range")]
+    Overflow,
+
+    /// The logarithmic value did not map to an integral count.
+    #[error("logarithmic copy-number value did not map to an integral count")]
+    NonIntegral,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum LogarithmicBase {
+    Two,
+    Ten,
+}
+
+impl LogarithmicBase {
+    fn powf(self, value: f64) -> f64 {
+        match self {
+            Self::Two => 2.0_f64.powf(value),
+            Self::Ten => 10.0_f64.powf(value),
+        }
+    }
 }
 
 /// An error related to a copy-number variant.
@@ -95,7 +250,7 @@ pub struct Variant {
     contig: Contig,
     start: Position<Interbase>,
     end: Position<Interbase>,
-    copies: u32,
+    count: Count,
 }
 
 impl Variant {
@@ -118,7 +273,7 @@ impl Variant {
             contig,
             start: InterbasePosition::new(start),
             end: InterbasePosition::new(end),
-            copies,
+            count: Count::new(copies),
         })
     }
 
@@ -138,13 +293,13 @@ impl Variant {
     }
 
     /// Gets the number of copies.
-    pub fn copies(&self) -> u32 {
-        self.copies
+    pub fn count(&self) -> Count {
+        self.count
     }
 
     /// Classifies the variant against a baseline copy number.
-    pub fn change(&self, baseline: u32) -> Change {
-        match self.copies.cmp(&baseline) {
+    pub fn change(&self, baseline: Count) -> Change {
+        match self.count.cmp(&baseline) {
             Ordering::Less => Change::Loss,
             Ordering::Equal => Change::Baseline,
             Ordering::Greater => Change::Gain,
@@ -195,7 +350,7 @@ impl fmt::Display for Variant {
             contig = self.contig,
             start = self.start.get(),
             end = self.end.get(),
-            copies = self.copies,
+            copies = self.count.get(),
             sep = VARIANT_SEPARATOR,
         )
     }

--- a/omics-variation/src/copy_number.rs
+++ b/omics-variation/src/copy_number.rs
@@ -169,6 +169,18 @@ pub enum LogarithmicError {
     NonIntegral,
 }
 
+/// An error related to logarithmic variant construction.
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum LogarithmicVariantError {
+    /// The logarithmic copy count was invalid.
+    #[error(transparent)]
+    Logarithmic(#[from] LogarithmicError),
+
+    /// The variant interval was invalid.
+    #[error(transparent)]
+    Variant(#[from] Error),
+}
+
 /// A logarithmic base used for copy-number conversion.
 #[derive(Debug, Clone, Copy)]
 enum LogarithmicBase {
@@ -309,6 +321,43 @@ impl Variant {
             count: Count::new(copies),
             ploidy,
         })
+    }
+
+    /// Attempts to create a copy-number variant from a base-2 logarithmic
+    /// ratio.
+    pub fn try_from_log2(
+        contig: impl TryInto<Contig, Error = contig::Error>,
+        start: Number,
+        end: Number,
+        value: f64,
+        ploidy: Ploidy,
+    ) -> Result<Self, LogarithmicVariantError> {
+        let count = Count::try_from_log2(value, ploidy)?;
+        Ok(Self::try_from_count(contig, start, end, count, ploidy)?)
+    }
+
+    /// Attempts to create a copy-number variant from a base-10 logarithmic
+    /// ratio.
+    pub fn try_from_log10(
+        contig: impl TryInto<Contig, Error = contig::Error>,
+        start: Number,
+        end: Number,
+        value: f64,
+        ploidy: Ploidy,
+    ) -> Result<Self, LogarithmicVariantError> {
+        let count = Count::try_from_log10(value, ploidy)?;
+        Ok(Self::try_from_count(contig, start, end, count, ploidy)?)
+    }
+
+    /// Attempts to create a new copy-number variant from a validated count.
+    fn try_from_count(
+        contig: impl TryInto<Contig, Error = contig::Error>,
+        start: Number,
+        end: Number,
+        count: Count,
+        ploidy: Ploidy,
+    ) -> Result<Self, Error> {
+        Self::try_new(contig, start, end, count.get(), ploidy)
     }
 
     /// Gets the contig this variant sits on.

--- a/omics-variation/src/copy_number.rs
+++ b/omics-variation/src/copy_number.rs
@@ -86,10 +86,6 @@ impl Count {
             return Err(LogarithmicError::Underflow);
         }
 
-        if copies > f64::from(u32::MAX) {
-            return Err(LogarithmicError::Overflow);
-        }
-
         let rounded = copies.round();
         if rounded == 0.0 {
             return Err(LogarithmicError::Underflow);
@@ -98,6 +94,10 @@ impl Count {
         let tolerance = 8.0 * f64::EPSILON * copies.abs().max(1.0);
         if (copies - rounded).abs() > tolerance {
             return Err(LogarithmicError::NonIntegral);
+        }
+
+        if rounded > f64::from(u32::MAX) {
+            return Err(LogarithmicError::Overflow);
         }
 
         Ok(Self::new(rounded as u32))
@@ -247,10 +247,16 @@ pub enum ParseError {
     /// The region end precedes the start.
     #[error("copy-number region end must be greater than start")]
     ReversedRegion,
+}
 
-    /// Construction failed after parsing.
-    #[error(transparent)]
-    Construct(#[from] Error),
+impl From<Error> for ParseError {
+    fn from(value: Error) -> Self {
+        match value {
+            Error::Contig(err) => Self::Contig(err),
+            Error::EmptyRegion => Self::EmptyRegion,
+            Error::ReversedRegion => Self::ReversedRegion,
+        }
+    }
 }
 
 /// A strandless, half-open copy-number variant.
@@ -351,7 +357,7 @@ impl FromStr for Variant {
             copies: (*copies).to_string(),
         })?;
 
-        Variant::try_new(*contig, start.get(), end.get(), copies).map_err(ParseError::Construct)
+        Ok(Variant::try_new(*contig, start.get(), end.get(), copies)?)
     }
 }
 

--- a/omics-variation/src/copy_number.rs
+++ b/omics-variation/src/copy_number.rs
@@ -1,0 +1,202 @@
+//! Copy-number variants.
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::str::FromStr;
+
+use omics_coordinate::Contig;
+use omics_coordinate::Position;
+use omics_coordinate::contig;
+use omics_coordinate::position::Number;
+use omics_coordinate::position::interbase::Position as InterbasePosition;
+use omics_coordinate::system::Interbase;
+use omics_core::VARIANT_SEPARATOR;
+use thiserror::Error;
+
+/// The copy-number change relative to a baseline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Change {
+    /// The observed copy number is below baseline.
+    Loss,
+    /// The observed copy number matches baseline.
+    Baseline,
+    /// The observed copy number is above baseline.
+    Gain,
+}
+
+/// An error related to a copy-number variant.
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum Error {
+    /// The contig failed to parse.
+    #[error(transparent)]
+    Contig(#[from] contig::Error),
+
+    /// The region has no span.
+    #[error("copy-number region cannot be empty")]
+    EmptyRegion,
+
+    /// The region end precedes the start.
+    #[error("copy-number region end must be greater than start")]
+    ReversedRegion,
+}
+
+/// An error related to parsing a copy-number variant.
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum ParseError {
+    /// The variant did not have the three colon-separated fields.
+    #[error("invalid copy-number format: `{0}`")]
+    Format(String),
+
+    /// The position range did not end with the interbase qualifier.
+    #[error("copy-number range `{region}` must end with `(i)` for an interbase coordinate")]
+    Qualifier {
+        /// The offending range token.
+        region: String,
+    },
+
+    /// The position range was malformed.
+    #[error("invalid copy-number range: `{range}`")]
+    Range {
+        /// The offending range token.
+        range: String,
+    },
+
+    /// The contig failed to parse.
+    #[error(transparent)]
+    Contig(#[from] contig::Error),
+
+    /// The start or end position failed to parse.
+    #[error(transparent)]
+    Position(#[from] omics_coordinate::position::Error),
+
+    /// The copy count failed to parse.
+    #[error("invalid copy-number count: `{copies}`")]
+    Copies {
+        /// The offending count token.
+        copies: String,
+    },
+
+    /// The region has no span.
+    #[error("copy-number region cannot be empty")]
+    EmptyRegion,
+
+    /// The region end precedes the start.
+    #[error("copy-number region end must be greater than start")]
+    ReversedRegion,
+
+    /// Construction failed after parsing.
+    #[error(transparent)]
+    Construct(#[from] Error),
+}
+
+/// A strandless, half-open copy-number variant.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Variant {
+    contig: Contig,
+    start: Position<Interbase>,
+    end: Position<Interbase>,
+    copies: u32,
+}
+
+impl Variant {
+    /// Attempts to create a new copy-number variant.
+    pub fn try_new(
+        contig: impl TryInto<Contig, Error = contig::Error>,
+        start: Number,
+        end: Number,
+        copies: u32,
+    ) -> Result<Self, Error> {
+        let contig = contig.try_into()?;
+
+        match start.cmp(&end) {
+            Ordering::Equal => return Err(Error::EmptyRegion),
+            Ordering::Greater => return Err(Error::ReversedRegion),
+            Ordering::Less => {}
+        }
+
+        Ok(Self {
+            contig,
+            start: InterbasePosition::new(start),
+            end: InterbasePosition::new(end),
+            copies,
+        })
+    }
+
+    /// Gets the contig this variant sits on.
+    pub fn contig(&self) -> &Contig {
+        &self.contig
+    }
+
+    /// Gets the start position.
+    pub fn start(&self) -> &Position<Interbase> {
+        &self.start
+    }
+
+    /// Gets the end position.
+    pub fn end(&self) -> &Position<Interbase> {
+        &self.end
+    }
+
+    /// Gets the number of copies.
+    pub fn copies(&self) -> u32 {
+        self.copies
+    }
+
+    /// Classifies the variant against a baseline copy number.
+    pub fn change(&self, baseline: u32) -> Change {
+        match self.copies.cmp(&baseline) {
+            Ordering::Less => Change::Loss,
+            Ordering::Equal => Change::Baseline,
+            Ordering::Greater => Change::Gain,
+        }
+    }
+}
+
+impl FromStr for Variant {
+    type Err = ParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let parts = value.split(VARIANT_SEPARATOR).collect::<Vec<_>>();
+        let [contig, range, copies] = parts.as_slice() else {
+            return Err(ParseError::Format(value.to_string()));
+        };
+
+        let range = range
+            .strip_suffix("(i)")
+            .ok_or_else(|| ParseError::Qualifier {
+                region: (*range).to_string(),
+            })?;
+
+        let (start, end) = range.split_once('-').ok_or_else(|| ParseError::Range {
+            range: range.to_string(),
+        })?;
+
+        if start.is_empty() || end.is_empty() || end.contains('-') {
+            return Err(ParseError::Range {
+                range: range.to_string(),
+            });
+        }
+
+        let start = start.parse::<InterbasePosition>()?;
+        let end = end.parse::<InterbasePosition>()?;
+        let copies = copies.parse::<u32>().map_err(|_| ParseError::Copies {
+            copies: (*copies).to_string(),
+        })?;
+
+        Variant::try_new(*contig, start.get(), end.get(), copies).map_err(ParseError::Construct)
+    }
+}
+
+impl fmt::Display for Variant {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{contig}{sep}{start}-{end}(i){sep}{copies}",
+            contig = self.contig,
+            start = self.start.get(),
+            end = self.end.get(),
+            copies = self.copies,
+            sep = VARIANT_SEPARATOR,
+        )
+    }
+}

--- a/omics-variation/src/copy_number.rs
+++ b/omics-variation/src/copy_number.rs
@@ -62,6 +62,7 @@ impl Count {
         ratio.log10()
     }
 
+    /// Converts a logarithmic ratio at the given base into an absolute count.
     fn try_from_logarithmic(
         value: f64,
         ploidy: Ploidy,
@@ -168,13 +169,17 @@ pub enum LogarithmicError {
     NonIntegral,
 }
 
+/// A logarithmic base used for copy-number conversion.
 #[derive(Debug, Clone, Copy)]
 enum LogarithmicBase {
+    /// Base 2 ratios.
     Two,
+    /// Base 10 ratios.
     Ten,
 }
 
 impl LogarithmicBase {
+    /// Raises the selected base to the provided exponent.
     fn powf(self, value: f64) -> f64 {
         match self {
             Self::Two => 2.0_f64.powf(value),
@@ -251,9 +256,13 @@ pub enum ParseError {
 /// A strandless, half-open copy-number variant.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Variant {
+    /// The contig containing the affected interval.
     contig: Contig,
+    /// The half-open start position.
     start: Position<Interbase>,
+    /// The half-open end position.
     end: Position<Interbase>,
+    /// The observed copy count over the interval.
     count: Count,
 }
 

--- a/omics-variation/src/lib.rs
+++ b/omics-variation/src/lib.rs
@@ -57,6 +57,11 @@
 //! use omics_variation::CopyNumberPloidy;
 //! use omics_variation::CopyNumberVariant;
 //!
+//! let reference =
+//!     CopyNumberVariant::try_new("seq0", 100, 200, 2, CopyNumberPloidy::DIPLOID)?;
+//! assert_eq!(reference.count().get(), reference.ploidy().get());
+//! assert_eq!(reference.change(), CopyNumberChange::Reference);
+//!
 //! let variant =
 //!     CopyNumberVariant::try_new("seq0", 100, 200, 3, CopyNumberPloidy::DIPLOID)?;
 //! assert_eq!(variant.change(), CopyNumberChange::Gain);

--- a/omics-variation/src/lib.rs
+++ b/omics-variation/src/lib.rs
@@ -57,13 +57,11 @@
 //! use omics_variation::CopyNumberPloidy;
 //! use omics_variation::CopyNumberVariant;
 //!
-//! let reference =
-//!     CopyNumberVariant::try_new("seq0", 100, 200, 2, CopyNumberPloidy::DIPLOID)?;
+//! let reference = CopyNumberVariant::try_new("seq0", 100, 200, 2, CopyNumberPloidy::DIPLOID)?;
 //! assert_eq!(reference.count().get(), reference.ploidy().get());
 //! assert_eq!(reference.change(), CopyNumberChange::Reference);
 //!
-//! let variant =
-//!     CopyNumberVariant::try_new("seq0", 100, 200, 3, CopyNumberPloidy::DIPLOID)?;
+//! let variant = CopyNumberVariant::try_new("seq0", 100, 200, 3, CopyNumberPloidy::DIPLOID)?;
 //! assert_eq!(variant.change(), CopyNumberChange::Gain);
 //!
 //! let log2 = variant.log2();

--- a/omics-variation/src/lib.rs
+++ b/omics-variation/src/lib.rs
@@ -76,7 +76,7 @@
 //!
 //! # Variant strings
 //!
-//! The crate uses a compact, crate-local string format:
+//! The crate uses a compact, crate-local string format.
 //!
 //! ```text
 //! contig:[strand:]position(system):reference:alternate

--- a/omics-variation/src/lib.rs
+++ b/omics-variation/src/lib.rs
@@ -1,4 +1,4 @@
-//! Sequence and structural variants.
+//! Sequence, copy-number, and structural variants.
 //!
 //! `omics-variation` represents genomic changes that can be written as a
 //! reference allele and an alternate allele at one locus. This covers single
@@ -16,6 +16,13 @@
 //! insertions, inversions, tandem duplications, and translocations. A
 //! structural variant derives its [`structural::Kind`] from breakend geometry
 //! rather than storing it.
+//!
+//! The [`copy_number`] module models strandless, half-open copy-number
+//! observations with typed absolute counts and typed ploidy baselines.
+//! Top-level aliases such as [`CopyNumberVariant`] keep these types available
+//! alongside [`Variant`] and [`StructuralVariant`]. Unlike [`structural`], a
+//! copy-number variant records an observed count over an interval and does not
+//! encode a breakpoint adjacency.
 //!
 //! ```
 //! use omics_molecule::polymer::dna;
@@ -42,6 +49,29 @@
 //! let variant = StructuralVariant::try_new(vec![adjacency])?;
 //! assert_eq!(variant.kind(), StructuralKind::Deletion);
 //! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! ```
+//! use omics_variation::CopyNumberVariant;
+//!
+//! let variant = "seq0:100-200(i):3".parse::<CopyNumberVariant>()?;
+//! assert_eq!(variant.count().get(), 3);
+//! assert_eq!(variant.to_string(), "seq0:100-200(i):3");
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! ```
+//! use omics_variation::CopyNumberCount;
+//! use omics_variation::CopyNumberPloidy;
+//!
+//! let count = CopyNumberCount::new(3);
+//! let log2 = count.log2(CopyNumberPloidy::DIPLOID);
+//!
+//! assert_eq!(
+//!     CopyNumberCount::try_from_log2(log2, CopyNumberPloidy::DIPLOID)?,
+//!     count
+//! );
+//! # Ok::<(), omics_variation::copy_number::LogarithmicError>(())
 //! ```
 //!
 //! # Variant strings
@@ -111,7 +141,8 @@
 //!
 //! let variant = "seq0:+:100(i):.:AT".parse::<Variant<dna::Nucleotide>>()?;
 //! let Variant::Insertion(insertion) = variant else {
-//!     unreachable!("the empty reference allele classifies as an insertion");
+//!     // SAFETY: an empty reference allele always classifies as an insertion.
+//!     unreachable!();
 //! };
 //!
 //! let interval = insertion.interbase_interval();
@@ -175,10 +206,18 @@ use omics_molecule::compound::Nucleotide;
 use omics_molecule::sequence::Sequence;
 use thiserror::Error;
 
-pub mod small;
 pub mod copy_number;
+pub mod small;
 pub mod structural;
 
+/// The top-level alias for a copy-number change.
+pub use copy_number::Change as CopyNumberChange;
+/// The top-level alias for a typed copy-number count.
+pub use copy_number::Count as CopyNumberCount;
+/// The top-level alias for a typed copy-number ploidy.
+pub use copy_number::Ploidy as CopyNumberPloidy;
+/// The top-level alias for a copy-number variant.
+pub use copy_number::Variant as CopyNumberVariant;
 /// The small-variant module, retained at its historical path.
 pub use small as variant;
 use small::Alteration;
@@ -748,6 +787,7 @@ mod tests {
 
     #[test]
     fn it_reports_reference_and_alternate_intervals() {
+        // SAFETY: this canonical insertion parses successfully.
         let insertion = "seq0:+:100(i):.:AT"
             .parse::<Variant<dna::Nucleotide>>()
             .unwrap();
@@ -755,6 +795,7 @@ mod tests {
             insertion.reference_interval(),
             VariantInterval::Interbase(_)
         ));
+        // SAFETY: insertions always expose an alternate interval.
         match insertion.alternate_interval().unwrap() {
             VariantInterval::Base(interval) => {
                 assert_eq!(interval.start().position().get(), 101);
@@ -763,6 +804,7 @@ mod tests {
             VariantInterval::Interbase(_) => panic!("expected base alternate interval"),
         }
 
+        // SAFETY: this canonical deletion parses successfully.
         let deletion = "seq0:+:100(b):AT:."
             .parse::<Variant<dna::Nucleotide>>()
             .unwrap();
@@ -770,6 +812,7 @@ mod tests {
             deletion.reference_interval(),
             VariantInterval::Base(_)
         ));
+        // SAFETY: deletions always expose an alternate interval.
         match deletion.alternate_interval().unwrap() {
             VariantInterval::Interbase(interval) => {
                 assert_eq!(interval.start().position().get(), 99);
@@ -798,12 +841,10 @@ mod tests {
     }
 
     fn normalized(input: &str) -> String {
-        input
-            .parse::<Variant<dna::Nucleotide>>()
-            .unwrap()
-            .normalize()
-            .unwrap()
-            .to_string()
+        // SAFETY: this helper only receives canonical small-variant strings.
+        let variant = input.parse::<Variant<dna::Nucleotide>>().unwrap();
+        // SAFETY: these test inputs normalize without overflowing coordinates.
+        variant.normalize().unwrap().to_string()
     }
 
     #[test]
@@ -821,9 +862,11 @@ mod tests {
     #[test]
     fn it_collapses_to_an_insertion_at_the_correct_boundary() {
         // `A:AT` at base 100 inserts `T` after base 100 -> interbase 100.
+        // SAFETY: this canonical delins parses successfully.
         let variant = "seq0:+:100(b):A:AT"
             .parse::<Variant<dna::Nucleotide>>()
             .unwrap();
+        // SAFETY: this test case normalizes without overflowing coordinates.
         let normalized = variant.normalize().unwrap();
         assert_eq!(normalized.kind(), Kind::Insertion);
         assert_eq!(normalized.to_string(), "seq0:+:100(i):.:T");
@@ -837,9 +880,11 @@ mod tests {
 
     #[test]
     fn it_collapses_delins_to_a_deletion() {
+        // SAFETY: this canonical delins parses successfully.
         let variant = "seq0:+:100(b):ATG:AG"
             .parse::<Variant<dna::Nucleotide>>()
             .unwrap();
+        // SAFETY: this test case normalizes without overflowing coordinates.
         let normalized = variant.normalize().unwrap();
         assert_eq!(normalized.kind(), Kind::Deletion);
         assert_eq!(normalized.to_string(), "seq0:+:101(b):T:.");
@@ -851,11 +896,10 @@ mod tests {
     }
 
     fn normalized_kind_and_string(input: &str) -> (Kind, String) {
-        let normalized = input
-            .parse::<Variant<dna::Nucleotide>>()
-            .unwrap()
-            .normalize()
-            .unwrap();
+        // SAFETY: this helper only receives canonical small-variant strings.
+        let variant = input.parse::<Variant<dna::Nucleotide>>().unwrap();
+        // SAFETY: these test inputs normalize without overflowing coordinates.
+        let normalized = variant.normalize().unwrap();
         (normalized.kind(), normalized.to_string())
     }
 

--- a/omics-variation/src/lib.rs
+++ b/omics-variation/src/lib.rs
@@ -176,6 +176,7 @@ use omics_molecule::sequence::Sequence;
 use thiserror::Error;
 
 pub mod small;
+pub mod copy_number;
 pub mod structural;
 
 /// The small-variant module, retained at its historical path.

--- a/omics-variation/src/lib.rs
+++ b/omics-variation/src/lib.rs
@@ -54,9 +54,9 @@
 //! ```
 //! use omics_variation::CopyNumberVariant;
 //!
-//! let variant = "seq0:100-200(i):3".parse::<CopyNumberVariant>()?;
+//! let variant = "seq0:100-200(i):3/2".parse::<CopyNumberVariant>()?;
 //! assert_eq!(variant.count().get(), 3);
-//! assert_eq!(variant.to_string(), "seq0:100-200(i):3");
+//! assert_eq!(variant.to_string(), "seq0:100-200(i):3/2");
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 //!

--- a/omics-variation/src/lib.rs
+++ b/omics-variation/src/lib.rs
@@ -18,11 +18,12 @@
 //! rather than storing it.
 //!
 //! The [`copy_number`] module models strandless, half-open copy-number
-//! observations with typed absolute counts and typed ploidy baselines.
-//! Top-level aliases such as [`CopyNumberVariant`] keep these types available
-//! alongside [`Variant`] and [`StructuralVariant`]. Unlike [`structural`], a
-//! copy-number variant records an observed count over an interval and does not
-//! encode a breakpoint adjacency.
+//! observations with typed absolute counts and required reference ploidy as
+//! part of variant identity. Top-level aliases such as [`CopyNumberVariant`]
+//! keep these types available alongside [`Variant`] and
+//! [`StructuralVariant`]. Unlike [`structural`], a copy-number variant records
+//! an observed count over an interval, carries the reference ploidy that
+//! interprets that count, and does not encode a breakpoint adjacency.
 //!
 //! ```
 //! use omics_molecule::polymer::dna;
@@ -48,6 +49,29 @@
 //! let adjacency = Adjacency::<dna::Nucleotide>::try_new_paired(a, b, ".".parse()?)?;
 //! let variant = StructuralVariant::try_new(vec![adjacency])?;
 //! assert_eq!(variant.kind(), StructuralKind::Deletion);
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! ```
+//! use omics_variation::CopyNumberChange;
+//! use omics_variation::CopyNumberPloidy;
+//! use omics_variation::CopyNumberVariant;
+//!
+//! let variant =
+//!     CopyNumberVariant::try_new("seq0", 100, 200, 3, CopyNumberPloidy::DIPLOID)?;
+//! assert_eq!(variant.change(), CopyNumberChange::Gain);
+//!
+//! let log2 = variant.log2();
+//! let log10 = variant.log10();
+//!
+//! assert_eq!(
+//!     CopyNumberVariant::try_from_log2("seq0", 100, 200, log2, CopyNumberPloidy::DIPLOID)?,
+//!     variant
+//! );
+//! assert_eq!(
+//!     CopyNumberVariant::try_from_log10("seq0", 100, 200, log10, CopyNumberPloidy::DIPLOID)?,
+//!     variant
+//! );
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 //!

--- a/omics-variation/tests/copy_number.rs
+++ b/omics-variation/tests/copy_number.rs
@@ -139,3 +139,13 @@ fn accepts_negative_infinity_and_tolerant_rounding() {
     assert!(Count::new(0).log10(Ploidy::DIPLOID).is_infinite());
     assert!(Count::new(0).log10(Ploidy::DIPLOID).is_sign_negative());
 }
+
+#[test]
+fn rejects_finite_inputs_that_round_to_zero() {
+    let tiny_log2 = (5e-301_f64).log2();
+
+    assert_eq!(
+        Count::try_from_log2(tiny_log2, Ploidy::DIPLOID),
+        Err(LogarithmicError::Underflow)
+    );
+}

--- a/omics-variation/tests/copy_number.rs
+++ b/omics-variation/tests/copy_number.rs
@@ -144,6 +144,18 @@ fn rejects_invalid_logarithmic_values() {
 }
 
 #[test]
+fn final_review_accepts_a_maximum_count_log2_round_trip_within_tolerance() {
+    let max_count = Count::new(u32::MAX);
+    let log2 = max_count.log2(Ploidy::DIPLOID);
+
+    // SAFETY: a logarithmic round trip from a valid maximum count must
+    // reconstruct the same count when it stays within tolerance.
+    let round_trip = Count::try_from_log2(log2, Ploidy::DIPLOID).unwrap();
+
+    assert_eq!(round_trip, max_count);
+}
+
+#[test]
 fn accepts_negative_infinity_and_tolerant_rounding() {
     // SAFETY: negative infinity is defined to round-trip to zero copies.
     let zero_from_log2 = Count::try_from_log2(f64::NEG_INFINITY, Ploidy::DIPLOID).unwrap();
@@ -171,4 +183,25 @@ fn rejects_finite_inputs_that_round_to_zero() {
         Count::try_from_log2(tiny_log2, Ploidy::DIPLOID),
         Err(LogarithmicError::Underflow)
     );
+}
+
+#[test]
+fn final_review_maps_an_invalid_contig_to_the_dedicated_parse_error() {
+    let err = ":100-200(i):3".parse::<Variant>().unwrap_err();
+
+    assert!(matches!(err, ParseError::Contig(_)));
+}
+
+#[test]
+fn final_review_maps_an_empty_region_to_the_dedicated_parse_error() {
+    let err = "seq0:100-100(i):3".parse::<Variant>().unwrap_err();
+
+    assert_eq!(err, ParseError::EmptyRegion);
+}
+
+#[test]
+fn final_review_maps_a_reversed_region_to_the_dedicated_parse_error() {
+    let err = "seq0:200-100(i):3".parse::<Variant>().unwrap_err();
+
+    assert_eq!(err, ParseError::ReversedRegion);
 }

--- a/omics-variation/tests/copy_number.rs
+++ b/omics-variation/tests/copy_number.rs
@@ -94,6 +94,21 @@ fn reference_ploidy_participates_in_identity() {
 }
 
 #[test]
+fn round_trips_a_non_diploid_variant_through_the_canonical_form() {
+    // SAFETY: `4` is a valid nonzero ploidy.
+    let tetraploid = Ploidy::try_new(4).unwrap();
+    // SAFETY: the constructor is expected to accept this valid contig, span, and tetraploid ploidy.
+    let variant = Variant::try_new("seq0", 100, 200, 3, tetraploid).unwrap();
+    let rendered = variant.to_string();
+
+    assert_eq!(rendered, "seq0:100-200(i):3/4");
+    // SAFETY: parsing a displayed valid variant should reconstruct the original value.
+    let reparsed = rendered.parse::<Variant>().unwrap();
+
+    assert_eq!(reparsed, variant);
+}
+
+#[test]
 fn classifies_loss_reference_gain_and_complete_loss() {
     // SAFETY: the constructor is expected to accept this valid contig, span, and diploid ploidy.
     let loss = Variant::try_new("seq0", 100, 200, 1, Ploidy::DIPLOID).unwrap();
@@ -126,9 +141,9 @@ fn rejects_empty_and_reversed_regions() {
 #[test]
 fn parses_and_displays_the_canonical_form() {
     // SAFETY: the parser is expected to accept the canonical copy-number form.
-    let variant = "seq0:100-200(i):3".parse::<Variant>().unwrap();
+    let variant = "seq0:100-200(i):3/2".parse::<Variant>().unwrap();
     assert_eq!(variant.ploidy(), Ploidy::DIPLOID);
-    assert_eq!(variant.to_string(), "seq0:100-200(i):3");
+    assert_eq!(variant.to_string(), "seq0:100-200(i):3/2");
 }
 
 #[test]
@@ -137,7 +152,7 @@ fn round_trips_a_variant_whose_contig_contains_separators() {
     let variant = Variant::try_new("assembly:chr:1", 100, 200, 3, Ploidy::DIPLOID).unwrap();
     let rendered = variant.to_string();
 
-    assert_eq!(rendered, "assembly:chr:1:100-200(i):3");
+    assert_eq!(rendered, "assembly:chr:1:100-200(i):3/2");
     // SAFETY: parsing a displayed valid variant should reconstruct the original value.
     let reparsed = rendered.parse::<Variant>().unwrap();
 
@@ -146,20 +161,43 @@ fn round_trips_a_variant_whose_contig_contains_separators() {
 
 #[test]
 fn rejects_a_missing_interbase_qualifier() {
-    let err = "seq0:100-200:3".parse::<Variant>().unwrap_err();
+    let err = "seq0:100-200:3/2".parse::<Variant>().unwrap_err();
     assert!(matches!(err, ParseError::Qualifier { .. }));
 }
 
 #[test]
 fn rejects_a_malformed_position_range() {
-    let err = "seq0:100200(i):3".parse::<Variant>().unwrap_err();
+    let err = "seq0:100200(i):3/2".parse::<Variant>().unwrap_err();
     assert!(matches!(err, ParseError::Range { .. }));
 }
 
 #[test]
 fn rejects_a_non_integral_count() {
-    let err = "seq0:100-200(i):3.5".parse::<Variant>().unwrap_err();
+    let err = "seq0:100-200(i):3.5/2".parse::<Variant>().unwrap_err();
     assert!(matches!(err, ParseError::Copies { .. }));
+}
+
+#[test]
+fn rejects_a_count_only_copy_number_string() {
+    let err = "seq0:100-200(i):3".parse::<Variant>().unwrap_err();
+
+    assert_eq!(err, ParseError::Format("seq0:100-200(i):3".to_string()));
+}
+
+#[test]
+fn rejects_an_invalid_ploidy() {
+    let err = "seq0:100-200(i):3/not-a-number"
+        .parse::<Variant>()
+        .unwrap_err();
+
+    assert!(matches!(err, ParseError::Ploidy { .. }));
+}
+
+#[test]
+fn rejects_a_zero_ploidy() {
+    let err = "seq0:100-200(i):3/0".parse::<Variant>().unwrap_err();
+
+    assert_eq!(err, ParseError::ZeroPloidy);
 }
 
 #[test]
@@ -229,21 +267,21 @@ fn rejects_finite_inputs_that_round_to_zero() {
 
 #[test]
 fn final_review_maps_an_invalid_contig_to_the_dedicated_parse_error() {
-    let err = ":100-200(i):3".parse::<Variant>().unwrap_err();
+    let err = ":100-200(i):3/2".parse::<Variant>().unwrap_err();
 
     assert!(matches!(err, ParseError::Contig(_)));
 }
 
 #[test]
 fn final_review_maps_an_empty_region_to_the_dedicated_parse_error() {
-    let err = "seq0:100-100(i):3".parse::<Variant>().unwrap_err();
+    let err = "seq0:100-100(i):3/2".parse::<Variant>().unwrap_err();
 
     assert_eq!(err, ParseError::EmptyRegion);
 }
 
 #[test]
 fn final_review_maps_a_reversed_region_to_the_dedicated_parse_error() {
-    let err = "seq0:200-100(i):3".parse::<Variant>().unwrap_err();
+    let err = "seq0:200-100(i):3/2".parse::<Variant>().unwrap_err();
 
     assert_eq!(err, ParseError::ReversedRegion);
 }

--- a/omics-variation/tests/copy_number.rs
+++ b/omics-variation/tests/copy_number.rs
@@ -1,0 +1,60 @@
+#![expect(missing_docs, reason = "integration tests do not need crate docs")]
+
+use omics_variation::copy_number::{Change, Error, ParseError, Variant};
+
+#[test]
+fn constructs_and_classifies_a_copy_number_variant() {
+    // SAFETY: the constructor is expected to accept this valid contig and span.
+    let variant = Variant::try_new("seq0", 100, 200, 3).unwrap();
+    assert_eq!(variant.contig().as_str(), "seq0");
+    assert_eq!(variant.start().get(), 100);
+    assert_eq!(variant.end().get(), 200);
+    assert_eq!(variant.copies(), 3);
+    assert_eq!(variant.change(4), Change::Loss);
+    assert_eq!(variant.change(3), Change::Baseline);
+    assert_eq!(variant.change(2), Change::Gain);
+}
+
+#[test]
+fn accepts_complete_copy_loss() {
+    // SAFETY: the constructor is expected to accept a complete copy loss.
+    let variant = Variant::try_new("seq0", 100, 200, 0).unwrap();
+    assert_eq!(variant.copies(), 0);
+}
+
+#[test]
+fn rejects_empty_and_reversed_regions() {
+    assert!(matches!(
+        Variant::try_new("seq0", 100, 100, 2),
+        Err(Error::EmptyRegion)
+    ));
+    assert!(matches!(
+        Variant::try_new("seq0", 200, 100, 2),
+        Err(Error::ReversedRegion)
+    ));
+}
+
+#[test]
+fn parses_and_displays_the_canonical_form() {
+    // SAFETY: the parser is expected to accept the canonical copy-number form.
+    let variant = "seq0:100-200(i):3".parse::<Variant>().unwrap();
+    assert_eq!(variant.to_string(), "seq0:100-200(i):3");
+}
+
+#[test]
+fn rejects_a_missing_interbase_qualifier() {
+    let err = "seq0:100-200:3".parse::<Variant>().unwrap_err();
+    assert!(matches!(err, ParseError::Qualifier { .. }));
+}
+
+#[test]
+fn rejects_a_malformed_position_range() {
+    let err = "seq0:100200(i):3".parse::<Variant>().unwrap_err();
+    assert!(matches!(err, ParseError::Range { .. }));
+}
+
+#[test]
+fn rejects_a_non_integral_count() {
+    let err = "seq0:100-200(i):3.5".parse::<Variant>().unwrap_err();
+    assert!(matches!(err, ParseError::Copies { .. }));
+}

--- a/omics-variation/tests/copy_number.rs
+++ b/omics-variation/tests/copy_number.rs
@@ -16,6 +16,10 @@ use omics_variation::copy_number::Variant;
 
 #[test]
 fn imports_top_level_copy_number_aliases() {
+    let reference = CopyNumberVariant::try_new("seq0", 100, 200, 2, CopyNumberPloidy::DIPLOID);
+    // SAFETY: the constructor is expected to accept this valid contig, span, and
+    // reference ploidy where the count equals the stored ploidy.
+    let reference = reference.unwrap();
     let variant = CopyNumberVariant::try_new("seq0", 100, 200, 3, CopyNumberPloidy::DIPLOID);
     // SAFETY: the constructor is expected to accept this valid contig, span, and
     // ploidy.
@@ -29,6 +33,8 @@ fn imports_top_level_copy_number_aliases() {
     let parsed = parsed.unwrap();
 
     assert_eq!(count, CopyNumberCount::new(3));
+    assert_eq!(reference.count().get(), reference.ploidy().get());
+    assert_eq!(reference.change(), CopyNumberChange::Reference);
     assert_eq!(variant.ploidy(), CopyNumberPloidy::DIPLOID);
     let count_from_log2 = CopyNumberCount::try_from_log2(log2, CopyNumberPloidy::DIPLOID);
     // SAFETY: `log2(3 / 2)` round-trips to the original typed copy-number count.

--- a/omics-variation/tests/copy_number.rs
+++ b/omics-variation/tests/copy_number.rs
@@ -102,6 +102,19 @@ fn parses_and_displays_the_canonical_form() {
 }
 
 #[test]
+fn round_trips_a_variant_whose_contig_contains_separators() {
+    // SAFETY: the constructor is expected to accept this non-empty contig and span.
+    let variant = Variant::try_new("assembly:chr:1", 100, 200, 3).unwrap();
+    let rendered = variant.to_string();
+
+    assert_eq!(rendered, "assembly:chr:1:100-200(i):3");
+    // SAFETY: parsing a displayed valid variant should reconstruct the original value.
+    let reparsed = rendered.parse::<Variant>().unwrap();
+
+    assert_eq!(reparsed, variant);
+}
+
+#[test]
 fn rejects_a_missing_interbase_qualifier() {
     let err = "seq0:100-200:3".parse::<Variant>().unwrap_err();
     assert!(matches!(err, ParseError::Qualifier { .. }));

--- a/omics-variation/tests/copy_number.rs
+++ b/omics-variation/tests/copy_number.rs
@@ -1,5 +1,9 @@
 #![expect(missing_docs, reason = "integration tests do not need crate docs")]
 
+use omics_variation::CopyNumberChange;
+use omics_variation::CopyNumberCount;
+use omics_variation::CopyNumberPloidy;
+use omics_variation::CopyNumberVariant;
 use omics_variation::copy_number::Change;
 use omics_variation::copy_number::Count;
 use omics_variation::copy_number::Error;
@@ -8,6 +12,25 @@ use omics_variation::copy_number::ParseError;
 use omics_variation::copy_number::Ploidy;
 use omics_variation::copy_number::PloidyError;
 use omics_variation::copy_number::Variant;
+
+#[test]
+fn imports_top_level_copy_number_aliases() {
+    // SAFETY: the constructor is expected to accept this valid contig and span.
+    let variant = CopyNumberVariant::try_new("seq0", 100, 200, 3).unwrap();
+    let count = variant.count();
+    let log2 = count.log2(CopyNumberPloidy::DIPLOID);
+
+    assert_eq!(count, CopyNumberCount::new(3));
+    // SAFETY: `log2(3 / 2)` round-trips to the original typed copy-number count.
+    assert_eq!(
+        CopyNumberCount::try_from_log2(log2, CopyNumberPloidy::DIPLOID).unwrap(),
+        count
+    );
+    assert_eq!(
+        variant.change(CopyNumberCount::new(2)),
+        CopyNumberChange::Gain
+    );
+}
 
 #[test]
 fn constructs_count_and_ploidy_values() {

--- a/omics-variation/tests/copy_number.rs
+++ b/omics-variation/tests/copy_number.rs
@@ -23,6 +23,10 @@ fn imports_top_level_copy_number_aliases() {
     let count = variant.count();
     let log2 = variant.log2();
     let log10 = variant.log10();
+    let parsed = "seq0:100-200(i):3/2".parse::<CopyNumberVariant>();
+    // SAFETY: the canonical top-level alias form contains a valid region, count,
+    // and reference ploidy.
+    let parsed = parsed.unwrap();
 
     assert_eq!(count, CopyNumberCount::new(3));
     assert_eq!(variant.ploidy(), CopyNumberPloidy::DIPLOID);
@@ -32,10 +36,24 @@ fn imports_top_level_copy_number_aliases() {
     let count_from_log10 = CopyNumberCount::try_from_log10(log10, CopyNumberPloidy::DIPLOID);
     // SAFETY: `log10(3 / 2)` round-trips to the original typed copy-number count.
     let count_from_log10 = count_from_log10.unwrap();
+    let variant_from_log2 =
+        CopyNumberVariant::try_from_log2("seq0", 100, 200, log2, CopyNumberPloidy::DIPLOID);
+    // SAFETY: `log2(3 / 2)` round-trips to the original top-level copy-number
+    // variant.
+    let variant_from_log2 = variant_from_log2.unwrap();
+    let variant_from_log10 =
+        CopyNumberVariant::try_from_log10("seq0", 100, 200, log10, CopyNumberPloidy::DIPLOID);
+    // SAFETY: `log10(3 / 2)` round-trips to the original top-level copy-number
+    // variant.
+    let variant_from_log10 = variant_from_log10.unwrap();
 
     assert_eq!(count_from_log2, count);
     assert_eq!(count_from_log10, count);
     assert_eq!(variant.change(), CopyNumberChange::Gain);
+    assert_eq!(parsed, variant);
+    assert_eq!(variant_from_log2, variant);
+    assert_eq!(variant_from_log10, variant);
+    assert_eq!(variant.to_string(), "seq0:100-200(i):3/2");
 }
 
 #[test]

--- a/omics-variation/tests/copy_number.rs
+++ b/omics-variation/tests/copy_number.rs
@@ -1,6 +1,43 @@
 #![expect(missing_docs, reason = "integration tests do not need crate docs")]
 
-use omics_variation::copy_number::{Change, Error, ParseError, Variant};
+use omics_variation::copy_number::Change;
+use omics_variation::copy_number::Count;
+use omics_variation::copy_number::Error;
+use omics_variation::copy_number::LogarithmicError;
+use omics_variation::copy_number::ParseError;
+use omics_variation::copy_number::Ploidy;
+use omics_variation::copy_number::PloidyError;
+use omics_variation::copy_number::Variant;
+
+#[test]
+fn constructs_count_and_ploidy_values() {
+    assert_eq!(Count::new(3).get(), 3);
+    assert_eq!(Ploidy::HAPLOID.get(), 1);
+    assert_eq!(Ploidy::DIPLOID.get(), 2);
+    // SAFETY: `4` is a valid nonzero ploidy.
+    assert_eq!(Ploidy::try_new(4).unwrap().get(), 4);
+    // SAFETY: `4` is a valid nonzero ploidy.
+    assert_eq!(Ploidy::try_from(4).unwrap().get(), 4);
+    assert_eq!(Ploidy::try_new(0), Err(PloidyError::Zero));
+    assert_eq!(Ploidy::try_from(0), Err(PloidyError::Zero));
+}
+
+#[test]
+fn converts_exact_counts_to_and_from_logarithmic_ratios() {
+    let count = Count::new(3);
+    let log2 = (1.5_f64).log2();
+    let log10 = (1.5_f64).log10();
+
+    // SAFETY: `log2(3 / 2)` maps exactly back to three copies at diploid ploidy.
+    let from_log2 = Count::try_from_log2(log2, Ploidy::DIPLOID).unwrap();
+    // SAFETY: `log10(3 / 2)` maps exactly back to three copies at diploid ploidy.
+    let from_log10 = Count::try_from_log10(log10, Ploidy::DIPLOID).unwrap();
+
+    assert_eq!(from_log2, count);
+    assert_eq!(from_log10, count);
+    assert!((count.log2(Ploidy::DIPLOID) - log2).abs() < f64::EPSILON);
+    assert!((count.log10(Ploidy::DIPLOID) - log10).abs() < f64::EPSILON);
+}
 
 #[test]
 fn constructs_and_classifies_a_copy_number_variant() {
@@ -9,17 +46,17 @@ fn constructs_and_classifies_a_copy_number_variant() {
     assert_eq!(variant.contig().as_str(), "seq0");
     assert_eq!(variant.start().get(), 100);
     assert_eq!(variant.end().get(), 200);
-    assert_eq!(variant.copies(), 3);
-    assert_eq!(variant.change(4), Change::Loss);
-    assert_eq!(variant.change(3), Change::Baseline);
-    assert_eq!(variant.change(2), Change::Gain);
+    assert_eq!(variant.count(), Count::new(3));
+    assert_eq!(variant.change(Count::new(4)), Change::Loss);
+    assert_eq!(variant.change(Count::new(3)), Change::Baseline);
+    assert_eq!(variant.change(Count::new(2)), Change::Gain);
 }
 
 #[test]
 fn accepts_complete_copy_loss() {
     // SAFETY: the constructor is expected to accept a complete copy loss.
     let variant = Variant::try_new("seq0", 100, 200, 0).unwrap();
-    assert_eq!(variant.copies(), 0);
+    assert_eq!(variant.count(), Count::new(0));
 }
 
 #[test]
@@ -57,4 +94,48 @@ fn rejects_a_malformed_position_range() {
 fn rejects_a_non_integral_count() {
     let err = "seq0:100-200(i):3.5".parse::<Variant>().unwrap_err();
     assert!(matches!(err, ParseError::Copies { .. }));
+}
+
+#[test]
+fn rejects_invalid_logarithmic_values() {
+    assert_eq!(
+        Count::try_from_log2(f64::NAN, Ploidy::DIPLOID),
+        Err(LogarithmicError::NotANumber)
+    );
+    assert_eq!(
+        Count::try_from_log10(f64::INFINITY, Ploidy::DIPLOID),
+        Err(LogarithmicError::PositiveInfinity)
+    );
+    assert_eq!(
+        Count::try_from_log2(-1076.0, Ploidy::DIPLOID),
+        Err(LogarithmicError::Underflow)
+    );
+    assert_eq!(
+        Count::try_from_log2(((f64::from(u32::MAX) + 1.0) / 2.0).log2(), Ploidy::DIPLOID),
+        Err(LogarithmicError::Overflow)
+    );
+    assert_eq!(
+        Count::try_from_log2((1.25_f64).log2(), Ploidy::DIPLOID),
+        Err(LogarithmicError::NonIntegral)
+    );
+}
+
+#[test]
+fn accepts_negative_infinity_and_tolerant_rounding() {
+    // SAFETY: negative infinity is defined to round-trip to zero copies.
+    let zero_from_log2 = Count::try_from_log2(f64::NEG_INFINITY, Ploidy::DIPLOID).unwrap();
+    // SAFETY: negative infinity is defined to round-trip to zero copies.
+    let zero_from_log10 = Count::try_from_log10(f64::NEG_INFINITY, Ploidy::DIPLOID).unwrap();
+    let within_tolerance = ((3.0 + 12.0 * f64::EPSILON) / 2.0).log2();
+
+    // SAFETY: this logarithmic ratio stays within the approved integral tolerance.
+    let tolerated = Count::try_from_log2(within_tolerance, Ploidy::DIPLOID).unwrap();
+
+    assert_eq!(zero_from_log2, Count::new(0));
+    assert_eq!(zero_from_log10, Count::new(0));
+    assert_eq!(tolerated, Count::new(3));
+    assert!(Count::new(0).log2(Ploidy::DIPLOID).is_infinite());
+    assert!(Count::new(0).log2(Ploidy::DIPLOID).is_sign_negative());
+    assert!(Count::new(0).log10(Ploidy::DIPLOID).is_infinite());
+    assert!(Count::new(0).log10(Ploidy::DIPLOID).is_sign_negative());
 }

--- a/omics-variation/tests/copy_number.rs
+++ b/omics-variation/tests/copy_number.rs
@@ -8,6 +8,7 @@ use omics_variation::copy_number::Change;
 use omics_variation::copy_number::Count;
 use omics_variation::copy_number::Error;
 use omics_variation::copy_number::LogarithmicError;
+use omics_variation::copy_number::LogarithmicVariantError;
 use omics_variation::copy_number::ParseError;
 use omics_variation::copy_number::Ploidy;
 use omics_variation::copy_number::PloidyError;
@@ -16,7 +17,8 @@ use omics_variation::copy_number::Variant;
 #[test]
 fn imports_top_level_copy_number_aliases() {
     let variant = CopyNumberVariant::try_new("seq0", 100, 200, 3, CopyNumberPloidy::DIPLOID);
-    // SAFETY: the constructor is expected to accept this valid contig, span, and ploidy.
+    // SAFETY: the constructor is expected to accept this valid contig, span, and
+    // ploidy.
     let variant = variant.unwrap();
     let count = variant.count();
     let log2 = variant.log2();
@@ -68,7 +70,8 @@ fn converts_exact_counts_to_and_from_logarithmic_ratios() {
 
 #[test]
 fn stores_reference_ploidy_and_derives_change() {
-    // SAFETY: the constructor is expected to accept this valid contig, span, and diploid ploidy.
+    // SAFETY: the constructor is expected to accept this valid contig, span, and
+    // diploid ploidy.
     let variant = Variant::try_new("seq0", 100, 200, 3, Ploidy::DIPLOID).unwrap();
 
     assert_eq!(variant.contig().as_str(), "seq0");
@@ -82,12 +85,114 @@ fn stores_reference_ploidy_and_derives_change() {
 }
 
 #[test]
+fn constructs_variants_from_exact_logarithmic_ratios() {
+    let diploid_log2 = Variant::try_from_log2("seq0", 100, 200, (1.5_f64).log2(), Ploidy::DIPLOID);
+    // SAFETY: `log2(3 / 2)` must reconstruct three copies at diploid ploidy.
+    let diploid_log2 = diploid_log2.unwrap();
+    let haploid_log10 = Variant::try_from_log10("seq0", 300, 400, 0.0, Ploidy::HAPLOID);
+    // SAFETY: `log10(1 / 1)` must reconstruct one copy at haploid ploidy.
+    let haploid_log10 = haploid_log10.unwrap();
+    // SAFETY: `4` is a valid nonzero ploidy.
+    let tetraploid = Ploidy::try_new(4).unwrap();
+    let tetraploid_log2 = Variant::try_from_log2("seq0", 500, 600, (1.5_f64).log2(), tetraploid);
+    // SAFETY: `log2(6 / 4)` must reconstruct six copies while preserving tetraploid
+    // identity.
+    let tetraploid_log2 = tetraploid_log2.unwrap();
+
+    assert_eq!(diploid_log2.count(), Count::new(3));
+    assert_eq!(diploid_log2.ploidy(), Ploidy::DIPLOID);
+    assert_eq!(diploid_log2.change(), Change::Gain);
+    assert_eq!(haploid_log10.count(), Count::new(1));
+    assert_eq!(haploid_log10.ploidy(), Ploidy::HAPLOID);
+    assert_eq!(haploid_log10.change(), Change::Reference);
+    assert_eq!(tetraploid_log2.count(), Count::new(6));
+    assert_eq!(tetraploid_log2.ploidy(), tetraploid);
+    assert_eq!(tetraploid_log2.change(), Change::Gain);
+}
+
+#[test]
+fn constructs_logarithmic_variants_for_complete_copy_loss() {
+    let zero_from_log2 =
+        Variant::try_from_log2("seq0", 100, 200, f64::NEG_INFINITY, Ploidy::DIPLOID);
+    // SAFETY: negative infinity is defined to map to zero copies.
+    let zero_from_log2 = zero_from_log2.unwrap();
+    let zero_from_log10 =
+        Variant::try_from_log10("seq0", 300, 400, f64::NEG_INFINITY, Ploidy::DIPLOID);
+    // SAFETY: negative infinity is defined to map to zero copies.
+    let zero_from_log10 = zero_from_log10.unwrap();
+
+    assert_eq!(zero_from_log2.count(), Count::new(0));
+    assert_eq!(zero_from_log2.ploidy(), Ploidy::DIPLOID);
+    assert_eq!(zero_from_log2.change(), Change::Loss);
+    assert_eq!(zero_from_log10.count(), Count::new(0));
+    assert_eq!(zero_from_log10.ploidy(), Ploidy::DIPLOID);
+    assert_eq!(zero_from_log10.change(), Change::Loss);
+}
+
+#[test]
+fn rejects_non_integral_logarithmic_variant_counts() {
+    let from_log2 = Variant::try_from_log2("seq0", 100, 200, (1.25_f64).log2(), Ploidy::DIPLOID);
+    let from_log10 = Variant::try_from_log10("seq0", 100, 200, (1.25_f64).log10(), Ploidy::DIPLOID);
+
+    assert_eq!(
+        from_log2,
+        Err(LogarithmicVariantError::Logarithmic(
+            LogarithmicError::NonIntegral,
+        ))
+    );
+    assert_eq!(
+        from_log10,
+        Err(LogarithmicVariantError::Logarithmic(
+            LogarithmicError::NonIntegral,
+        ))
+    );
+}
+
+#[test]
+fn rejects_overflow_and_underflow_in_logarithmic_variant_construction() {
+    let overflow = Variant::try_from_log2(
+        "seq0",
+        100,
+        200,
+        ((f64::from(u32::MAX) + 1.0) / 2.0).log2(),
+        Ploidy::DIPLOID,
+    );
+    let underflow =
+        Variant::try_from_log10("seq0", 100, 200, (5e-301_f64).log10(), Ploidy::DIPLOID);
+
+    assert_eq!(
+        overflow,
+        Err(LogarithmicVariantError::Logarithmic(
+            LogarithmicError::Overflow,
+        ))
+    );
+    assert_eq!(
+        underflow,
+        Err(LogarithmicVariantError::Logarithmic(
+            LogarithmicError::Underflow,
+        ))
+    );
+}
+
+#[test]
+fn rejects_invalid_contigs_in_logarithmic_variant_construction() {
+    let err = Variant::try_from_log2("", 100, 200, (1.5_f64).log2(), Ploidy::DIPLOID);
+
+    assert!(matches!(
+        err,
+        Err(LogarithmicVariantError::Variant(Error::Contig(_)))
+    ));
+}
+
+#[test]
 fn reference_ploidy_participates_in_identity() {
-    // SAFETY: the constructor is expected to accept this valid contig, span, and diploid ploidy.
+    // SAFETY: the constructor is expected to accept this valid contig, span, and
+    // diploid ploidy.
     let diploid = Variant::try_new("seq0", 100, 200, 3, Ploidy::DIPLOID).unwrap();
     // SAFETY: `3` is a valid nonzero ploidy.
     let triploid_ploidy = Ploidy::try_new(3).unwrap();
-    // SAFETY: the constructor is expected to accept this valid contig, span, and triploid ploidy.
+    // SAFETY: the constructor is expected to accept this valid contig, span, and
+    // triploid ploidy.
     let triploid = Variant::try_new("seq0", 100, 200, 3, triploid_ploidy).unwrap();
 
     assert_ne!(diploid, triploid);
@@ -97,12 +202,14 @@ fn reference_ploidy_participates_in_identity() {
 fn round_trips_a_non_diploid_variant_through_the_canonical_form() {
     // SAFETY: `4` is a valid nonzero ploidy.
     let tetraploid = Ploidy::try_new(4).unwrap();
-    // SAFETY: the constructor is expected to accept this valid contig, span, and tetraploid ploidy.
+    // SAFETY: the constructor is expected to accept this valid contig, span, and
+    // tetraploid ploidy.
     let variant = Variant::try_new("seq0", 100, 200, 3, tetraploid).unwrap();
     let rendered = variant.to_string();
 
     assert_eq!(rendered, "seq0:100-200(i):3/4");
-    // SAFETY: parsing a displayed valid variant should reconstruct the original value.
+    // SAFETY: parsing a displayed valid variant should reconstruct the original
+    // value.
     let reparsed = rendered.parse::<Variant>().unwrap();
 
     assert_eq!(reparsed, variant);
@@ -110,13 +217,17 @@ fn round_trips_a_non_diploid_variant_through_the_canonical_form() {
 
 #[test]
 fn classifies_loss_reference_gain_and_complete_loss() {
-    // SAFETY: the constructor is expected to accept this valid contig, span, and diploid ploidy.
+    // SAFETY: the constructor is expected to accept this valid contig, span, and
+    // diploid ploidy.
     let loss = Variant::try_new("seq0", 100, 200, 1, Ploidy::DIPLOID).unwrap();
-    // SAFETY: the constructor is expected to accept this valid contig, span, and diploid ploidy.
+    // SAFETY: the constructor is expected to accept this valid contig, span, and
+    // diploid ploidy.
     let reference = Variant::try_new("seq0", 100, 200, 2, Ploidy::DIPLOID).unwrap();
-    // SAFETY: the constructor is expected to accept this valid contig, span, and diploid ploidy.
+    // SAFETY: the constructor is expected to accept this valid contig, span, and
+    // diploid ploidy.
     let gain = Variant::try_new("seq0", 100, 200, 3, Ploidy::DIPLOID).unwrap();
-    // SAFETY: the constructor is expected to accept a complete copy loss with a valid diploid ploidy.
+    // SAFETY: the constructor is expected to accept a complete copy loss with a
+    // valid diploid ploidy.
     let complete_loss = Variant::try_new("seq0", 100, 200, 0, Ploidy::DIPLOID).unwrap();
 
     assert_eq!(loss.change(), Change::Loss);
@@ -148,12 +259,14 @@ fn parses_and_displays_the_canonical_form() {
 
 #[test]
 fn round_trips_a_variant_whose_contig_contains_separators() {
-    // SAFETY: the constructor is expected to accept this non-empty contig, span, and diploid ploidy.
+    // SAFETY: the constructor is expected to accept this non-empty contig, span,
+    // and diploid ploidy.
     let variant = Variant::try_new("assembly:chr:1", 100, 200, 3, Ploidy::DIPLOID).unwrap();
     let rendered = variant.to_string();
 
     assert_eq!(rendered, "assembly:chr:1:100-200(i):3/2");
-    // SAFETY: parsing a displayed valid variant should reconstruct the original value.
+    // SAFETY: parsing a displayed valid variant should reconstruct the original
+    // value.
     let reparsed = rendered.parse::<Variant>().unwrap();
 
     assert_eq!(reparsed, variant);
@@ -229,7 +342,8 @@ fn final_review_accepts_a_maximum_count_log2_round_trip_within_tolerance() {
     let max_count = Count::new(u32::MAX);
     let log2 = max_count.log2(Ploidy::DIPLOID);
 
-    // SAFETY: a logarithmic round trip from a valid maximum count must reconstruct the same count.
+    // SAFETY: a logarithmic round trip from a valid maximum count must reconstruct
+    // the same count.
     let round_trip = Count::try_from_log2(log2, Ploidy::DIPLOID).unwrap();
 
     assert_eq!(round_trip, max_count);

--- a/omics-variation/tests/copy_number.rs
+++ b/omics-variation/tests/copy_number.rs
@@ -15,21 +15,25 @@ use omics_variation::copy_number::Variant;
 
 #[test]
 fn imports_top_level_copy_number_aliases() {
-    // SAFETY: the constructor is expected to accept this valid contig and span.
-    let variant = CopyNumberVariant::try_new("seq0", 100, 200, 3).unwrap();
+    let variant = CopyNumberVariant::try_new("seq0", 100, 200, 3, CopyNumberPloidy::DIPLOID);
+    // SAFETY: the constructor is expected to accept this valid contig, span, and ploidy.
+    let variant = variant.unwrap();
     let count = variant.count();
-    let log2 = count.log2(CopyNumberPloidy::DIPLOID);
+    let log2 = variant.log2();
+    let log10 = variant.log10();
 
     assert_eq!(count, CopyNumberCount::new(3));
+    assert_eq!(variant.ploidy(), CopyNumberPloidy::DIPLOID);
+    let count_from_log2 = CopyNumberCount::try_from_log2(log2, CopyNumberPloidy::DIPLOID);
     // SAFETY: `log2(3 / 2)` round-trips to the original typed copy-number count.
-    assert_eq!(
-        CopyNumberCount::try_from_log2(log2, CopyNumberPloidy::DIPLOID).unwrap(),
-        count
-    );
-    assert_eq!(
-        variant.change(CopyNumberCount::new(2)),
-        CopyNumberChange::Gain
-    );
+    let count_from_log2 = count_from_log2.unwrap();
+    let count_from_log10 = CopyNumberCount::try_from_log10(log10, CopyNumberPloidy::DIPLOID);
+    // SAFETY: `log10(3 / 2)` round-trips to the original typed copy-number count.
+    let count_from_log10 = count_from_log10.unwrap();
+
+    assert_eq!(count_from_log2, count);
+    assert_eq!(count_from_log10, count);
+    assert_eq!(variant.change(), CopyNumberChange::Gain);
 }
 
 #[test]
@@ -63,33 +67,58 @@ fn converts_exact_counts_to_and_from_logarithmic_ratios() {
 }
 
 #[test]
-fn constructs_and_classifies_a_copy_number_variant() {
-    // SAFETY: the constructor is expected to accept this valid contig and span.
-    let variant = Variant::try_new("seq0", 100, 200, 3).unwrap();
+fn stores_reference_ploidy_and_derives_change() {
+    // SAFETY: the constructor is expected to accept this valid contig, span, and diploid ploidy.
+    let variant = Variant::try_new("seq0", 100, 200, 3, Ploidy::DIPLOID).unwrap();
+
     assert_eq!(variant.contig().as_str(), "seq0");
     assert_eq!(variant.start().get(), 100);
     assert_eq!(variant.end().get(), 200);
     assert_eq!(variant.count(), Count::new(3));
-    assert_eq!(variant.change(Count::new(4)), Change::Loss);
-    assert_eq!(variant.change(Count::new(3)), Change::Baseline);
-    assert_eq!(variant.change(Count::new(2)), Change::Gain);
+    assert_eq!(variant.ploidy(), Ploidy::DIPLOID);
+    assert_eq!(variant.change(), Change::Gain);
+    assert_eq!(variant.log2(), Count::new(3).log2(Ploidy::DIPLOID));
+    assert_eq!(variant.log10(), Count::new(3).log10(Ploidy::DIPLOID));
 }
 
 #[test]
-fn accepts_complete_copy_loss() {
-    // SAFETY: the constructor is expected to accept a complete copy loss.
-    let variant = Variant::try_new("seq0", 100, 200, 0).unwrap();
-    assert_eq!(variant.count(), Count::new(0));
+fn reference_ploidy_participates_in_identity() {
+    // SAFETY: the constructor is expected to accept this valid contig, span, and diploid ploidy.
+    let diploid = Variant::try_new("seq0", 100, 200, 3, Ploidy::DIPLOID).unwrap();
+    // SAFETY: `3` is a valid nonzero ploidy.
+    let triploid_ploidy = Ploidy::try_new(3).unwrap();
+    // SAFETY: the constructor is expected to accept this valid contig, span, and triploid ploidy.
+    let triploid = Variant::try_new("seq0", 100, 200, 3, triploid_ploidy).unwrap();
+
+    assert_ne!(diploid, triploid);
+}
+
+#[test]
+fn classifies_loss_reference_gain_and_complete_loss() {
+    // SAFETY: the constructor is expected to accept this valid contig, span, and diploid ploidy.
+    let loss = Variant::try_new("seq0", 100, 200, 1, Ploidy::DIPLOID).unwrap();
+    // SAFETY: the constructor is expected to accept this valid contig, span, and diploid ploidy.
+    let reference = Variant::try_new("seq0", 100, 200, 2, Ploidy::DIPLOID).unwrap();
+    // SAFETY: the constructor is expected to accept this valid contig, span, and diploid ploidy.
+    let gain = Variant::try_new("seq0", 100, 200, 3, Ploidy::DIPLOID).unwrap();
+    // SAFETY: the constructor is expected to accept a complete copy loss with a valid diploid ploidy.
+    let complete_loss = Variant::try_new("seq0", 100, 200, 0, Ploidy::DIPLOID).unwrap();
+
+    assert_eq!(loss.change(), Change::Loss);
+    assert_eq!(reference.change(), Change::Reference);
+    assert_eq!(gain.change(), Change::Gain);
+    assert_eq!(complete_loss.count(), Count::new(0));
+    assert_eq!(complete_loss.change(), Change::Loss);
 }
 
 #[test]
 fn rejects_empty_and_reversed_regions() {
     assert!(matches!(
-        Variant::try_new("seq0", 100, 100, 2),
+        Variant::try_new("seq0", 100, 100, 2, Ploidy::DIPLOID),
         Err(Error::EmptyRegion)
     ));
     assert!(matches!(
-        Variant::try_new("seq0", 200, 100, 2),
+        Variant::try_new("seq0", 200, 100, 2, Ploidy::DIPLOID),
         Err(Error::ReversedRegion)
     ));
 }
@@ -98,13 +127,14 @@ fn rejects_empty_and_reversed_regions() {
 fn parses_and_displays_the_canonical_form() {
     // SAFETY: the parser is expected to accept the canonical copy-number form.
     let variant = "seq0:100-200(i):3".parse::<Variant>().unwrap();
+    assert_eq!(variant.ploidy(), Ploidy::DIPLOID);
     assert_eq!(variant.to_string(), "seq0:100-200(i):3");
 }
 
 #[test]
 fn round_trips_a_variant_whose_contig_contains_separators() {
-    // SAFETY: the constructor is expected to accept this non-empty contig and span.
-    let variant = Variant::try_new("assembly:chr:1", 100, 200, 3).unwrap();
+    // SAFETY: the constructor is expected to accept this non-empty contig, span, and diploid ploidy.
+    let variant = Variant::try_new("assembly:chr:1", 100, 200, 3, Ploidy::DIPLOID).unwrap();
     let rendered = variant.to_string();
 
     assert_eq!(rendered, "assembly:chr:1:100-200(i):3");
@@ -161,8 +191,7 @@ fn final_review_accepts_a_maximum_count_log2_round_trip_within_tolerance() {
     let max_count = Count::new(u32::MAX);
     let log2 = max_count.log2(Ploidy::DIPLOID);
 
-    // SAFETY: a logarithmic round trip from a valid maximum count must
-    // reconstruct the same count when it stays within tolerance.
+    // SAFETY: a logarithmic round trip from a valid maximum count must reconstruct the same count.
     let round_trip = Count::try_from_log2(log2, Ploidy::DIPLOID).unwrap();
 
     assert_eq!(round_trip, max_count);


### PR DESCRIPTION
`omics-variation` modeled sequence and adjacency-defined structural changes but lacked a representation for an observed copy-number state relative to reference ploidy. This added strandless, half-open copy-number regions with typed absolute `Count` values, required nonzero `Ploidy`, and derived loss, reference, or gain classification.

The implementation added strict base-2 and base-10 conversion, canonical `contig:start-end(i):copies/ploidy` serialization, colon-safe parsing, public aliases, documentation, integration tests, and Criterion benchmarks. Counts remained integral by design; uncertain ranges, allele-specific counts, purity, confidence, and sample metadata remained outside this tier.

Before submitting this PR, please make sure:

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see [\"keep a changelog\"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[\"keep a changelog\"]: https://keepachangelog.com/en/1.1.0/