### PR TITLE
feat: add typed coordinate spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ following features are included and are top-level goals of the project.
 - **Coordinate systems (`omics::coordinate`)**. Provides multiple genomic coordinate
   systems including both a 0-based, half-open coordinate system (also known as the
   _interbase_ coordinate system) and 1-based, fully-closed coordinate system (also known
-  as the _in-base_ or just _base_ coordinate system).
+  as the _in-base_ or just _base_ coordinate system), plus typed positions, localized
+  coordinates, context-free spans, and localized intervals.
 - **Sequence alignments (`omics::alignment`).** Validated pairwise alignments with
   deterministic global and local affine-gap alignment over generic symbol slices,
   plus lossless per-operation traversal via `Alignment::steps`; callers can select

--- a/omics-alignment/src/alignment.rs
+++ b/omics-alignment/src/alignment.rs
@@ -205,7 +205,7 @@ impl Alignment {
     /// position on the positive strand and retreats it on the negative
     /// strand. Either way, the coordinate observed before the move and the
     /// coordinate observed after the move are ordered exactly as
-    /// [`Interval::try_new`] requires of a start and an end on that strand
+    /// [`Interval::try_from`] requires of a start and an end on that strand
     /// (start at or before end on the positive strand, end at or before
     /// start on the negative strand).
     ///
@@ -220,10 +220,9 @@ impl Alignment {
         let moved = pointer.move_forward(length);
         debug_assert!(moved, "movement already validated by Alignment::try_new");
 
-        // SAFETY: the proof on this function guarantees `start` and
-        // `pointer` are ordered as `Interval::try_new` requires for this
-        // strand.
-        Interval::try_new(start, pointer.clone()).unwrap()
+        // SAFETY: the proof above guarantees the endpoints have compatible context and
+        // direction.
+        Interval::try_from((start, pointer.clone())).unwrap()
     }
 }
 

--- a/omics-coordinate/CHANGELOG.md
+++ b/omics-coordinate/CHANGELOG.md
@@ -9,17 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added `Span<S>` and `span::Direction` for context-free directed geometry.
+* Added system-specific span emptiness and entity-count semantics, including
+  empty interbase spans for boundary events.
 * Added a `TryFrom<&str>` conversion for `Coordinate`, mirroring the existing
   `FromStr` so coordinates compose with `TryInto`-based constructors
   ([#15](https://github.com/stjude-rust-labs/omics/pull/15)).
+* Added coordinate-pair `TryFrom` support for `Interval<S>` so localized
+  endpoints still compose through `TryInto`.
 * Derived `Hash` for `Position`, `Base`, and `Interbase`
   ([#16](https://github.com/stjude-rust-labs/omics/pull/16)).
 * Added `CoordinateRef` for allocation-free access to interval endpoints.
 
 ### Changed
 
-* Compacted `Interval` storage so each interval stores its contig and strand
-  once.
+* `Interval` now owns its geometry as a `Span<S>`, so each interval stores its
+  contig and strand once.
+* `Interval::try_new` now takes `(contig, strand, span)`, which breaks callers
+  that previously constructed intervals from separate endpoint inputs.
 * Changed `Interval<Interbase>::into_equivalent_base()` to return `Option`.
   Zero-width interbase intervals return `None`.
 

--- a/omics-coordinate/CHANGELOG.md
+++ b/omics-coordinate/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   contig and strand once.
 * `Interval::try_new` now takes `(contig, strand, span)`, which breaks callers
   that previously constructed intervals from separate endpoint inputs.
+* Removed `NonsensicalError::NegativelySized`, added
+  `Error::DirectionMismatch`, and now report invalid strand and span direction
+  combinations with the typed direction error.
 * Changed `Interval<Interbase>::into_equivalent_base()` to return `Option`.
   Zero-width interbase intervals return `None`.
 

--- a/omics-coordinate/benches/intervals.rs
+++ b/omics-coordinate/benches/intervals.rs
@@ -29,7 +29,7 @@ pub mod interbase {
             Coordinate::<Interbase>::try_new(black_box("seq0"), black_box("+"), black_box(20))
                 .unwrap();
         // SAFETY: the endpoints share metadata and form a positively sized interval.
-        black_box(Interval::try_new(start, end).unwrap());
+        black_box(Interval::try_from((start, end)).unwrap());
     }
 
     pub fn benches(c: &mut Criterion) {
@@ -47,7 +47,7 @@ pub mod interbase {
                 || (start.clone(), end.clone()),
                 |(start, end)| {
                     // SAFETY: the prepared endpoints form a valid interval.
-                    black_box(Interval::try_new(start, end).unwrap())
+                    black_box(Interval::try_from((start, end)).unwrap())
                 },
                 BatchSize::SmallInput,
             )

--- a/omics-coordinate/benches/intervals.rs
+++ b/omics-coordinate/benches/intervals.rs
@@ -21,36 +21,43 @@ pub mod interbase {
     use omics_coordinate::system::Base;
     use omics_coordinate::system::Interbase;
 
+    /// Returns an ascending interbase span for benchmarking
     fn ascending_span() -> Span<Interbase> {
         // SAFETY: the benchmark endpoints form a valid interbase span.
         Span::<Interbase>::try_new(10, 20).unwrap()
     }
 
+    /// Returns a descending interbase span for benchmarking
     fn descending_span() -> Span<Interbase> {
         // SAFETY: the benchmark endpoints form a valid interbase span.
         Span::<Interbase>::try_new(20, 10).unwrap()
     }
 
+    /// Returns a descending operand interbase span for benchmarking
     fn descending_operand_span() -> Span<Interbase> {
         // SAFETY: the benchmark endpoints form a valid interbase span.
         Span::<Interbase>::try_new(18, 8).unwrap()
     }
 
+    /// Returns an ascending operand interbase span for benchmarking
     fn ascending_operand_span() -> Span<Interbase> {
         // SAFETY: the benchmark endpoints form a valid interbase span.
         Span::<Interbase>::try_new(15, 25).unwrap()
     }
 
+    /// Returns an empty interbase span for benchmarking
     fn empty_span() -> Span<Interbase> {
         // SAFETY: equal interbase endpoints are valid and represent an empty span.
         Span::<Interbase>::try_new(10, 10).unwrap()
     }
 
+    /// Returns an ascending interbase interval for benchmarking
     fn interval() -> Interval<Interbase> {
         // SAFETY: the positive strand accepts ascending spans.
         Interval::try_new("seq0", "+", ascending_span()).unwrap()
     }
 
+    /// Returns an ascending operand interbase interval for benchmarking
     fn operand_interval() -> Interval<Interbase> {
         // SAFETY: the positive strand accepts ascending spans.
         Interval::try_new("seq0", "+", ascending_operand_span()).unwrap()

--- a/omics-coordinate/benches/intervals.rs
+++ b/omics-coordinate/benches/intervals.rs
@@ -1,4 +1,4 @@
-//! Benchmarks for intervals.
+//! Benchmarks for spans and intervals.
 #![allow(missing_docs)]
 
 use criterion::criterion_group;
@@ -16,10 +16,90 @@ pub mod interbase {
     use criterion::Criterion;
     use omics_coordinate::Coordinate;
     use omics_coordinate::Interval;
+    use omics_coordinate::Position;
+    use omics_coordinate::Span;
+    use omics_coordinate::system::Base;
     use omics_coordinate::system::Interbase;
 
+    fn ascending_span() -> Span<Interbase> {
+        // SAFETY: the benchmark endpoints form a valid interbase span.
+        Span::<Interbase>::try_new(10, 20).unwrap()
+    }
+
+    fn descending_span() -> Span<Interbase> {
+        // SAFETY: the benchmark endpoints form a valid interbase span.
+        Span::<Interbase>::try_new(20, 10).unwrap()
+    }
+
+    fn descending_operand_span() -> Span<Interbase> {
+        // SAFETY: the benchmark endpoints form a valid interbase span.
+        Span::<Interbase>::try_new(18, 8).unwrap()
+    }
+
+    fn ascending_operand_span() -> Span<Interbase> {
+        // SAFETY: the benchmark endpoints form a valid interbase span.
+        Span::<Interbase>::try_new(15, 25).unwrap()
+    }
+
+    fn empty_span() -> Span<Interbase> {
+        // SAFETY: equal interbase endpoints are valid and represent an empty span.
+        Span::<Interbase>::try_new(10, 10).unwrap()
+    }
+
+    fn interval() -> Interval<Interbase> {
+        // SAFETY: the positive strand accepts ascending spans.
+        Interval::try_new("seq0", "+", ascending_span()).unwrap()
+    }
+
+    fn operand_interval() -> Interval<Interbase> {
+        // SAFETY: the positive strand accepts ascending spans.
+        Interval::try_new("seq0", "+", ascending_operand_span()).unwrap()
+    }
+
+    /// Benchmarks span construction from raw position numbers.
+    fn span_try_new() {
+        // SAFETY: the benchmark endpoints form a valid interbase span.
+        black_box(Span::<Interbase>::try_new(black_box(10), black_box(20)).unwrap());
+    }
+
+    /// Benchmarks span parsing.
+    fn span_parse() {
+        // SAFETY: the benchmark input is a valid interbase span string.
+        black_box(black_box("20-10").parse::<Span<Interbase>>().unwrap());
+    }
+
+    /// Benchmarks span display formatting.
+    fn span_display(span: &Span<Interbase>) {
+        black_box(black_box(span).to_string());
+    }
+
+    /// Benchmarks span direction queries.
+    fn span_direction(span: &Span<Interbase>) {
+        black_box(black_box(span).direction());
+    }
+
+    /// Benchmarks span emptiness queries.
+    fn span_is_empty(span: &Span<Interbase>) {
+        black_box(black_box(span).is_empty());
+    }
+
+    /// Benchmarks span position containment.
+    fn span_contains_position(span: &Span<Interbase>, position: &Position<Interbase>) {
+        black_box(black_box(span).contains_position(black_box(position)));
+    }
+
+    /// Benchmarks span offset lookup from the start.
+    fn span_position_offset(span: &Span<Interbase>, position: &Position<Interbase>) {
+        black_box(black_box(span).position_offset(black_box(position)));
+    }
+
+    /// Benchmarks span offset lookup into the span.
+    fn span_position_at_offset(span: &Span<Interbase>) {
+        black_box(black_box(span).position_at_offset(black_box(5)));
+    }
+
     /// Benchmarks interval construction from raw coordinate parts.
-    fn from_raw_coordinates() {
+    fn coordinate_pair_try_from_raw() {
         // SAFETY: the benchmark inputs form a valid interbase coordinate.
         let start =
             Coordinate::<Interbase>::try_new(black_box("seq0"), black_box("+"), black_box(10))
@@ -32,22 +112,155 @@ pub mod interbase {
         black_box(Interval::try_from((start, end)).unwrap());
     }
 
+    /// Benchmarks interval construction from contextual data and a span.
+    fn interval_try_new() {
+        // SAFETY: the benchmark endpoints form a valid interbase span.
+        let span = Span::<Interbase>::try_new(black_box(10), black_box(20)).unwrap();
+        // SAFETY: the positive strand accepts ascending spans.
+        black_box(Interval::try_new(black_box("seq0"), black_box("+"), span).unwrap());
+    }
+
+    /// Benchmarks interval coordinate containment.
+    fn interval_contains_coordinate(
+        interval: &Interval<Interbase>,
+        coordinate: &Coordinate<Interbase>,
+    ) {
+        black_box(black_box(interval).contains_coordinate(black_box(coordinate)));
+    }
+
+    /// Benchmarks interval entity containment.
+    fn interval_contains_entity(interval: &Interval<Interbase>, coordinate: &Coordinate<Base>) {
+        black_box(black_box(interval).contains_entity(black_box(coordinate)));
+    }
+
+    /// Benchmarks interval entity counting.
+    fn interval_count_entities(interval: &Interval<Interbase>) {
+        black_box(black_box(interval).count_entities());
+    }
+
+    /// Benchmarks interval coordinate offsets.
+    fn interval_coordinate_offset(
+        interval: &Interval<Interbase>,
+        coordinate: &Coordinate<Interbase>,
+    ) {
+        black_box(black_box(interval).coordinate_offset(black_box(coordinate)));
+    }
+
+    /// Benchmarks interval coordinate lookup by offset.
+    fn interval_coordinate_at_offset(interval: &Interval<Interbase>) {
+        black_box(black_box(interval).coordinate_at_offset(black_box(5)));
+    }
+
     pub fn benches(c: &mut Criterion) {
-        c.bench_function("intervals::interbase::from_raw_coordinates", |b| {
-            b.iter(from_raw_coordinates)
+        let ascending = ascending_span();
+        let descending = descending_span();
+        let descending_operand = descending_operand_span();
+        let empty = empty_span();
+        let position = Position::<Interbase>::new(15);
+        let interval = interval();
+        let operand = operand_interval();
+        // SAFETY: the benchmark coordinate points to a valid entity on the interval
+        // contig.
+        let entity = Coordinate::<Base>::try_new("seq0", "+", 15).unwrap();
+        // SAFETY: the benchmark coordinate shares the interval context and lies within
+        // the span.
+        let coordinate = Coordinate::<Interbase>::try_new("seq0", "+", 15).unwrap();
+
+        c.bench_function("intervals::interbase::span_try_new", |b| {
+            b.iter(span_try_new)
         });
-
-        // SAFETY: the benchmark inputs form a valid interbase coordinate.
-        let start = Coordinate::<Interbase>::try_new("seq0", "+", 10).unwrap();
-        // SAFETY: the benchmark inputs form a valid interbase coordinate.
-        let end = Coordinate::<Interbase>::try_new("seq0", "+", 20).unwrap();
-
+        c.bench_function("intervals::interbase::span_parse", |b| b.iter(span_parse));
+        c.bench_function("intervals::interbase::span_display", |b| {
+            b.iter(|| span_display(&descending))
+        });
+        c.bench_function("intervals::interbase::span_direction", |b| {
+            b.iter(|| span_direction(&descending))
+        });
+        c.bench_function("intervals::interbase::span_is_empty", |b| {
+            b.iter(|| span_is_empty(&empty))
+        });
+        c.bench_function("intervals::interbase::span_contains_position", |b| {
+            b.iter(|| span_contains_position(&ascending, &position))
+        });
+        c.bench_function("intervals::interbase::span_position_offset", |b| {
+            b.iter(|| span_position_offset(&descending, &position))
+        });
+        c.bench_function("intervals::interbase::span_position_at_offset", |b| {
+            b.iter(|| span_position_at_offset(&descending))
+        });
+        c.bench_function("intervals::interbase::span_reversed", |b| {
+            b.iter_batched(
+                descending_span,
+                |span| black_box(span.reversed()),
+                BatchSize::SmallInput,
+            )
+        });
+        c.bench_function("intervals::interbase::span_clamp", |b| {
+            b.iter_batched(
+                || (descending.clone(), descending_operand.clone()),
+                |(span, operand)| {
+                    // SAFETY: the prepared spans overlap and move in compatible directions.
+                    black_box(span.clamp(operand).unwrap())
+                },
+                BatchSize::SmallInput,
+            )
+        });
+        c.bench_function("intervals::interbase::coordinate_pair_try_from_raw", |b| {
+            b.iter(coordinate_pair_try_from_raw)
+        });
+        c.bench_function(
+            "intervals::interbase::coordinate_pair_try_from_prepared",
+            |b| {
+                b.iter_batched(
+                    || {
+                        // SAFETY: the benchmark inputs form a valid interbase coordinate.
+                        let start = Coordinate::<Interbase>::try_new("seq0", "+", 10).unwrap();
+                        // SAFETY: the benchmark inputs form a valid interbase coordinate.
+                        let end = Coordinate::<Interbase>::try_new("seq0", "+", 20).unwrap();
+                        (start, end)
+                    },
+                    |(start, end)| {
+                        // SAFETY: the prepared endpoints form a valid interval.
+                        black_box(Interval::try_from((start, end)).unwrap())
+                    },
+                    BatchSize::SmallInput,
+                )
+            },
+        );
+        c.bench_function("intervals::interbase::interval_try_new", |b| {
+            b.iter(interval_try_new)
+        });
         c.bench_function("intervals::interbase::try_new_prepared", |b| {
             b.iter_batched(
-                || (start.clone(), end.clone()),
-                |(start, end)| {
-                    // SAFETY: the prepared endpoints form a valid interval.
-                    black_box(Interval::try_from((start, end)).unwrap())
+                ascending_span,
+                |span| {
+                    // SAFETY: the positive strand accepts the prepared ascending span.
+                    black_box(Interval::try_new("seq0", "+", span).unwrap())
+                },
+                BatchSize::SmallInput,
+            )
+        });
+        c.bench_function("intervals::interbase::contains_coordinate", |b| {
+            b.iter(|| interval_contains_coordinate(&interval, &coordinate))
+        });
+        c.bench_function("intervals::interbase::contains_entity", |b| {
+            b.iter(|| interval_contains_entity(&interval, &entity))
+        });
+        c.bench_function("intervals::interbase::count_entities", |b| {
+            b.iter(|| interval_count_entities(&interval))
+        });
+        c.bench_function("intervals::interbase::coordinate_offset", |b| {
+            b.iter(|| interval_coordinate_offset(&interval, &coordinate))
+        });
+        c.bench_function("intervals::interbase::coordinate_at_offset", |b| {
+            b.iter(|| interval_coordinate_at_offset(&interval))
+        });
+        c.bench_function("intervals::interbase::interval_clamp", |b| {
+            b.iter_batched(
+                || (interval.clone(), operand.clone()),
+                |(interval, operand)| {
+                    // SAFETY: the prepared intervals share context and overlap.
+                    black_box(interval.clamp(operand).unwrap())
                 },
                 BatchSize::SmallInput,
             )

--- a/omics-coordinate/src/interval.rs
+++ b/omics-coordinate/src/interval.rs
@@ -1,28 +1,26 @@
 //! Intervals.
 
-use std::cmp::max;
-use std::cmp::min;
-
 use omics_core::VARIANT_SEPARATOR;
 use thiserror::Error;
 
 use crate::Contig;
 use crate::Position;
+use crate::Span;
 use crate::Strand;
 use crate::System;
+use crate::contig;
 use crate::coordinate;
 use crate::coordinate::Coordinate;
 use crate::coordinate::CoordinateRef;
 use crate::position;
 use crate::position::Number;
+use crate::span;
+use crate::span::Direction;
 use crate::strand;
 use crate::system::Base;
 
 pub mod base;
 pub mod interbase;
-
-/// The separator between an interval's start and end positions.
-const INTERVAL_SEPARATOR: &str = "-";
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // Errors
@@ -114,24 +112,6 @@ pub enum NonsensicalError {
         /// The strand of the interval doing the clamping.
         end: Strand,
     },
-
-    /// A negative sized interval.
-    ///
-    /// This error occurs when the start of the interval comes _after_ the end
-    /// of the interval.
-    ///
-    /// On positive stranded intervals, this is when the start position is
-    /// _greater than_ the end position. On negative stranded intervals, this is
-    /// when the start position is _less than_ the end position.
-    #[error("negatively sized interval: start is `{start}`, end is `{end}`, strand is `{strand}`")]
-    NegativelySized {
-        /// The start position.
-        start: Number,
-        /// The end position.
-        end: Number,
-        /// The strand.
-        strand: Strand,
-    },
 }
 
 /// A [`Result`](std::result::Result) with a [`NonsensicalError`].
@@ -158,9 +138,23 @@ pub enum Error {
     #[error("clamp error: {0}")]
     Clamp(#[from] ClampError),
 
+    /// A contig error.
+    #[error("contig error: {0}")]
+    Contig(#[from] contig::Error),
+
     /// A coordinate error.
     #[error("coordinate error: {0}")]
     Coordinate(#[from] coordinate::Error),
+
+    /// The span direction does not agree with the strand.
+    #[error("span direction `{direction}` is incompatible with strand `{strand}`")]
+    DirectionMismatch {
+        /// The interval strand.
+        strand: Strand,
+
+        /// The span direction.
+        direction: Direction,
+    },
 
     /// A nonsensical interval.
     #[error("nonsensical interval: {0}")]
@@ -216,11 +210,8 @@ pub struct Interval<S: System> {
     /// The strand.
     strand: Strand,
 
-    /// The start position.
-    start: Position<S>,
-
-    /// The end position.
-    end: Position<S>,
+    /// The directed span.
+    span: Span<S>,
 }
 
 impl<S: System> Interval<S>
@@ -228,107 +219,58 @@ where
     Interval<S>: r#trait::Interval<S>,
     Position<S>: position::r#trait::Position<S>,
 {
-    /// Creates a new interval if the following invariants are upheld.
+    /// Creates an interval from genomic context and a directed span.
     ///
-    /// * The contigs of the two coordinates must match.
-    ///   * If this does not hold, a [`NonsensicalError::MismatchedContigs`]
-    ///     will be returned.
-    /// * The strands of the two coordinates must match.
-    ///   * If this does not hold, a [`NonsensicalError::MismatchedStrands`]
-    ///     will be returned.
-    /// * The start must come _before or be equal to_ the end in that (a) on
-    ///   positive strand, `start <= end`, or, (b) on the negative strand, `end
-    ///   <= start`. This ensures that the interval is always oriented from
-    ///   start to end of the molecule.
-    ///   * If this does not hold, a [`NonsensicalError::NegativelySized`] will
-    ///     be returned.
+    /// Positive strands accept ascending and stationary spans. Negative
+    /// strands accept descending and stationary spans.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::DirectionMismatch`] when the span direction does not
+    /// agree with the strand.
     ///
     /// # Examples
     ///
     /// ```
-    /// use omics_coordinate::Coordinate;
     /// use omics_coordinate::Interval;
-    /// use omics_coordinate::system::Base;
+    /// use omics_coordinate::Span;
     /// use omics_coordinate::system::Interbase;
     ///
-    /// //===========//
-    /// // Interbase //
-    /// //===========//
-    ///
-    /// // Positive strand.
-    ///
-    /// let start = Coordinate::<Interbase>::try_new("seq0", "+", 10)?;
-    /// let end = Coordinate::<Interbase>::try_new("seq0", "+", 20)?;
-    /// let interval = Interval::try_new(start, end)?;
-    ///
-    /// // Negative strand.
-    ///
-    /// let start = Coordinate::<Interbase>::try_new("seq0", "-", 20)?;
-    /// let end = Coordinate::<Interbase>::try_new("seq0", "-", 10)?;
-    /// let interval = Interval::try_new(start, end)?;
-    ///
-    /// //======//
-    /// // Base //
-    /// //======//
-    ///
-    /// // Positive strand.
-    ///
-    /// let start = Coordinate::<Base>::try_new("seq0", "+", 10)?;
-    /// let end = Coordinate::<Base>::try_new("seq0", "+", 20)?;
-    /// let interval = Interval::try_new(start, end)?;
-    ///
-    /// // Negative strand.
-    ///
-    /// let start = Coordinate::<Base>::try_new("seq0", "-", 20)?;
-    /// let end = Coordinate::<Base>::try_new("seq0", "-", 10)?;
-    /// let interval = Interval::try_new(start, end)?;
+    /// let span = Span::<Interbase>::try_new(10, 20)?;
+    /// let interval = Interval::try_new("seq0", "+", span)?;
+    /// assert_eq!(interval.to_string(), "seq0:+:10-20");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn try_new(start: Coordinate<S>, end: Coordinate<S>) -> Result<super::Interval<S>> {
-        let (start_contig, start_strand, start_position) = start.into_parts();
-        let (end_contig, end_strand, end_position) = end.into_parts();
+    pub fn try_new(
+        contig: impl TryInto<Contig, Error = contig::Error>,
+        strand: impl TryInto<Strand, Error = strand::Error>,
+        span: Span<S>,
+    ) -> Result<Self> {
+        let contig = contig.try_into()?;
+        let strand = strand.try_into()?;
+        let compatible = matches!(
+            (strand, span.direction()),
+            (
+                Strand::Positive,
+                Direction::Ascending | Direction::Stationary
+            ) | (
+                Strand::Negative,
+                Direction::Descending | Direction::Stationary
+            )
+        );
 
-        if start_contig != end_contig {
-            return Err(Error::Nonsensical(NonsensicalError::MismatchedContigs {
-                start: start_contig,
-                end: end_contig,
-            }));
+        if !compatible {
+            return Err(Error::DirectionMismatch {
+                strand,
+                direction: span.direction(),
+            });
         }
 
-        if start_strand != end_strand {
-            return Err(Error::Nonsensical(NonsensicalError::MismatchedStrands {
-                start: start_strand,
-                end: end_strand,
-            }));
-        }
-
-        match start_strand {
-            Strand::Positive => {
-                if start_position > end_position {
-                    return Err(Error::Nonsensical(NonsensicalError::NegativelySized {
-                        start: start_position.get(),
-                        end: end_position.get(),
-                        strand: start_strand,
-                    }));
-                }
-            }
-            Strand::Negative => {
-                if end_position > start_position {
-                    return Err(Error::Nonsensical(NonsensicalError::NegativelySized {
-                        start: start_position.get(),
-                        end: end_position.get(),
-                        strand: start_strand,
-                    }));
-                }
-            }
-        }
-
-        Ok(Interval {
-            contig: start_contig,
-            strand: start_strand,
-            start: start_position,
-            end: end_position,
+        Ok(Self {
+            contig,
+            strand,
+            span,
         })
     }
 
@@ -348,7 +290,7 @@ where
     ///
     /// let start = Coordinate::<Interbase>::try_new("seq0", "+", 10)?;
     /// let end = Coordinate::<Interbase>::try_new("seq0", "+", 20)?;
-    /// let interval = Interval::try_new(start.clone(), end)?;
+    /// let interval = Interval::try_from((start.clone(), end))?;
     ///
     /// assert_eq!(interval.start().into_owned(), start);
     ///
@@ -358,14 +300,14 @@ where
     ///
     /// let start = Coordinate::<Base>::try_new("seq0", "+", 10)?;
     /// let end = Coordinate::<Base>::try_new("seq0", "+", 20)?;
-    /// let interval = Interval::try_new(start.clone(), end)?;
+    /// let interval = Interval::try_from((start.clone(), end))?;
     ///
     /// assert_eq!(interval.start().into_owned(), start);
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn start(&self) -> CoordinateRef<'_, S> {
-        CoordinateRef::new(&self.contig, self.strand, &self.start)
+        CoordinateRef::new(&self.contig, self.strand, self.span.start())
     }
 
     /// Consumes `self` and returns the start coordinate.
@@ -384,7 +326,7 @@ where
     ///
     /// let start = Coordinate::<Interbase>::try_new("seq0", "+", 10)?;
     /// let end = Coordinate::<Interbase>::try_new("seq0", "+", 20)?;
-    /// let interval = Interval::try_new(start.clone(), end)?;
+    /// let interval = Interval::try_from((start.clone(), end))?;
     ///
     /// assert_eq!(interval.into_start(), start);
     ///
@@ -394,14 +336,15 @@ where
     ///
     /// let start = Coordinate::<Base>::try_new("seq0", "+", 10)?;
     /// let end = Coordinate::<Base>::try_new("seq0", "+", 20)?;
-    /// let interval = Interval::try_new(start.clone(), end)?;
+    /// let interval = Interval::try_from((start.clone(), end))?;
     ///
     /// assert_eq!(interval.into_start(), start);
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn into_start(self) -> Coordinate<S> {
-        Coordinate::new(self.contig, self.strand, self.start)
+        let (start, _) = self.span.into_positions();
+        Coordinate::new(self.contig, self.strand, start)
     }
 
     /// Gets a borrowed end coordinate.
@@ -420,7 +363,7 @@ where
     ///
     /// let start = Coordinate::<Interbase>::try_new("seq0", "+", 10)?;
     /// let end = Coordinate::<Interbase>::try_new("seq0", "+", 20)?;
-    /// let interval = Interval::try_new(start, end.clone())?;
+    /// let interval = Interval::try_from((start, end.clone()))?;
     ///
     /// assert_eq!(interval.end().into_owned(), end);
     ///
@@ -430,14 +373,14 @@ where
     ///
     /// let start = Coordinate::<Base>::try_new("seq0", "+", 10)?;
     /// let end = Coordinate::<Base>::try_new("seq0", "+", 20)?;
-    /// let interval = Interval::try_new(start, end.clone())?;
+    /// let interval = Interval::try_from((start, end.clone()))?;
     ///
     /// assert_eq!(interval.end().into_owned(), end);
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn end(&self) -> CoordinateRef<'_, S> {
-        CoordinateRef::new(&self.contig, self.strand, &self.end)
+        CoordinateRef::new(&self.contig, self.strand, self.span.end())
     }
 
     /// Consumes `self` and returns the end coordinate.
@@ -456,7 +399,7 @@ where
     ///
     /// let start = Coordinate::<Interbase>::try_new("seq0", "+", 10)?;
     /// let end = Coordinate::<Interbase>::try_new("seq0", "+", 20)?;
-    /// let interval = Interval::try_new(start, end.clone())?;
+    /// let interval = Interval::try_from((start, end.clone()))?;
     ///
     /// assert_eq!(interval.into_end(), end);
     ///
@@ -466,14 +409,15 @@ where
     ///
     /// let start = Coordinate::<Base>::try_new("seq0", "+", 10)?;
     /// let end = Coordinate::<Base>::try_new("seq0", "+", 20)?;
-    /// let interval = Interval::try_new(start, end.clone())?;
+    /// let interval = Interval::try_from((start, end.clone()))?;
     ///
     /// assert_eq!(interval.into_end(), end);
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn into_end(self) -> Coordinate<S> {
-        Coordinate::new(self.contig, self.strand, self.end)
+        let (_, end) = self.span.into_positions();
+        Coordinate::new(self.contig, self.strand, end)
     }
 
     /// Consumes `self` and returns the start and end coordinates.
@@ -492,7 +436,7 @@ where
     ///
     /// let start = Coordinate::<Interbase>::try_new("seq0", "+", 10)?;
     /// let end = Coordinate::<Interbase>::try_new("seq0", "+", 20)?;
-    /// let interval = Interval::try_new(start.clone(), end.clone())?;
+    /// let interval = Interval::try_from((start.clone(), end.clone()))?;
     /// let parts = interval.into_coordinates();
     ///
     /// assert_eq!(parts.0, start);
@@ -504,7 +448,7 @@ where
     ///
     /// let start = Coordinate::<Base>::try_new("seq0", "+", 10)?;
     /// let end = Coordinate::<Base>::try_new("seq0", "+", 20)?;
-    /// let interval = Interval::try_new(start.clone(), end.clone())?;
+    /// let interval = Interval::try_from((start.clone(), end.clone()))?;
     /// let parts = interval.into_coordinates();
     ///
     /// assert_eq!(parts.0, start);
@@ -513,10 +457,21 @@ where
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn into_coordinates(self) -> (Coordinate<S>, Coordinate<S>) {
+        let (start, end) = self.span.into_positions();
         (
-            Coordinate::new(self.contig.clone(), self.strand, self.start),
-            Coordinate::new(self.contig, self.strand, self.end),
+            Coordinate::new(self.contig.clone(), self.strand, start),
+            Coordinate::new(self.contig, self.strand, end),
         )
+    }
+
+    /// Returns the directed span.
+    pub fn span(&self) -> &Span<S> {
+        &self.span
+    }
+
+    /// Consumes the interval and returns its directed span.
+    pub fn into_span(self) -> Span<S> {
+        self.span
     }
 
     /// Returns a reference to the contig.
@@ -535,7 +490,7 @@ where
     ///
     /// let start = Coordinate::<Interbase>::try_new("seq0", "+", 10)?;
     /// let end = Coordinate::<Interbase>::try_new("seq0", "+", 20)?;
-    /// let interval = Interval::try_new(start, end)?;
+    /// let interval = Interval::try_from((start, end))?;
     ///
     /// assert_eq!(interval.contig().as_str(), "seq0");
     ///
@@ -545,7 +500,7 @@ where
     ///
     /// let start = Coordinate::<Base>::try_new("seq0", "+", 10)?;
     /// let end = Coordinate::<Base>::try_new("seq0", "+", 20)?;
-    /// let interval = Interval::try_new(start, end)?;
+    /// let interval = Interval::try_from((start, end))?;
     ///
     /// assert_eq!(interval.contig().as_str(), "seq0");
     ///
@@ -572,7 +527,7 @@ where
     ///
     /// let start = Coordinate::<Interbase>::try_new("seq0", "+", 10)?;
     /// let end = Coordinate::<Interbase>::try_new("seq0", "+", 20)?;
-    /// let interval = Interval::try_new(start, end)?;
+    /// let interval = Interval::try_from((start, end))?;
     ///
     /// assert_eq!(interval.strand(), Strand::Positive);
     ///
@@ -582,7 +537,7 @@ where
     ///
     /// let start = Coordinate::<Base>::try_new("seq0", "-", 20)?;
     /// let end = Coordinate::<Base>::try_new("seq0", "-", 10)?;
-    /// let interval = Interval::try_new(start, end)?;
+    /// let interval = Interval::try_from((start, end))?;
     ///
     /// assert_eq!(interval.strand(), Strand::Negative);
     ///
@@ -624,7 +579,7 @@ where
     ///
     /// let start = Coordinate::<Interbase>::try_new("seq0", "+", 0)?;
     /// let end = Coordinate::<Interbase>::try_new("seq0", "+", 10)?;
-    /// let interval = Interval::try_new(start, end)?;
+    /// let interval = Interval::try_from((start, end))?;
     ///
     /// // Coordinates on the same contig, strand, and within the interval's range
     /// // are contained within the interval.
@@ -644,7 +599,7 @@ where
     ///
     /// let start = Coordinate::<Interbase>::try_new("seq0", "+", 1)?;
     /// let end = Coordinate::<Interbase>::try_new("seq0", "+", 10)?;
-    /// let interval = Interval::try_new(start, end)?;
+    /// let interval = Interval::try_from((start, end))?;
     ///
     /// // Coordinates on the same contig, strand, and within the interval's range
     /// // are contained within the interval.
@@ -661,24 +616,9 @@ where
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn contains_coordinate(&self, coordinate: &crate::Coordinate<S>) -> bool {
-        if self.contig() != coordinate.contig() {
-            return false;
-        }
-
-        if self.strand() != coordinate.strand() {
-            return false;
-        }
-
-        match self.strand() {
-            Strand::Positive => {
-                self.start().position().get() <= coordinate.position().get()
-                    && self.end().position().get() >= coordinate.position().get()
-            }
-            Strand::Negative => {
-                self.start().position().get() >= coordinate.position().get()
-                    && self.end().position().get() <= coordinate.position().get()
-            }
-        }
+        self.contig() == coordinate.contig()
+            && self.strand() == coordinate.strand()
+            && self.span.contains_position(coordinate.position())
     }
 
     /// Returns whether or not the entity at the in-base coordinate is
@@ -705,7 +645,7 @@ where
     ///
     /// let start = Coordinate::<Interbase>::try_new("seq0", "+", 0)?;
     /// let end = Coordinate::<Interbase>::try_new("seq0", "+", 10)?;
-    /// let interval = Interval::try_new(start, end)?;
+    /// let interval = Interval::try_from((start, end))?;
     ///
     /// // Coordinates on the same contig, strand, and within the interval's range
     /// // are contained within the interval.
@@ -725,7 +665,7 @@ where
     ///
     /// let start = Coordinate::<Interbase>::try_new("seq0", "+", 1)?;
     /// let end = Coordinate::<Interbase>::try_new("seq0", "+", 10)?;
-    /// let interval = Interval::try_new(start, end)?;
+    /// let interval = Interval::try_from((start, end))?;
     ///
     /// // Coordinates on the same contig, strand, and within the interval's range
     /// // are contained within the interval.
@@ -763,7 +703,7 @@ where
     ///
     /// let start = Coordinate::<Interbase>::try_new("seq0", "+", 10)?;
     /// let end = Coordinate::<Interbase>::try_new("seq0", "+", 20)?;
-    /// let interval = Interval::try_new(start, end)?;
+    /// let interval = Interval::try_from((start, end))?;
     ///
     /// assert_eq!(interval.count_entities(), 10);
     ///
@@ -771,7 +711,7 @@ where
     ///
     /// let start = Coordinate::<Interbase>::try_new("seq0", "-", 20)?;
     /// let end = Coordinate::<Interbase>::try_new("seq0", "-", 10)?;
-    /// let interval = Interval::try_new(start, end)?;
+    /// let interval = Interval::try_from((start, end))?;
     ///
     /// assert_eq!(interval.count_entities(), 10);
     ///
@@ -783,7 +723,7 @@ where
     ///
     /// let start = Coordinate::<Base>::try_new("seq0", "+", 10)?;
     /// let end = Coordinate::<Base>::try_new("seq0", "+", 20)?;
-    /// let interval = Interval::try_new(start, end)?;
+    /// let interval = Interval::try_from((start, end))?;
     ///
     /// assert_eq!(interval.count_entities(), 11);
     ///
@@ -791,7 +731,7 @@ where
     ///
     /// let start = Coordinate::<Base>::try_new("seq0", "-", 20)?;
     /// let end = Coordinate::<Base>::try_new("seq0", "-", 10)?;
-    /// let interval = Interval::try_new(start, end)?;
+    /// let interval = Interval::try_from((start, end))?;
     ///
     /// assert_eq!(interval.count_entities(), 11);
     ///
@@ -908,62 +848,53 @@ where
     #[must_use = "this method returns a new interval"]
     pub fn clamp(self, interval: Interval<S>) -> Result<Interval<S>> {
         let Self {
-            contig: start_contig,
-            strand: start_strand,
-            start,
-            end,
+            contig,
+            strand,
+            span,
         } = self;
         let Self {
             contig: operand_contig,
             strand: operand_strand,
-            start: operand_start,
-            end: operand_end,
+            span: operand_span,
         } = interval;
 
-        if start_contig != operand_contig {
+        if contig != operand_contig {
             return Err(Error::Clamp(ClampError::MismatchedContigs {
-                original: start_contig,
+                original: contig,
                 operand: operand_contig,
             }));
         }
 
-        if start_strand != operand_strand {
+        if strand != operand_strand {
             return Err(Error::Clamp(ClampError::MismatchedStrand {
-                original: start_strand,
+                original: strand,
                 operand: operand_strand,
             }));
         }
 
-        let original_start = start.get();
-        let original_end = end.get();
-        let operand_start_value = operand_start.get();
-        let operand_end_value = operand_end.get();
-
-        let (new_start, new_end) = match start_strand {
-            Strand::Positive => (max(start, operand_start), min(end, operand_end)),
-            Strand::Negative => (min(start, operand_start), max(end, operand_end)),
-        };
-
-        let disjoint = match start_strand {
-            Strand::Positive => new_start > new_end,
-            Strand::Negative => new_start < new_end,
-        };
-
-        if disjoint {
-            return Err(Error::Clamp(ClampError::Disjoint {
+        let span = span.clamp(operand_span).map_err(|error| match error {
+            span::ClampError::Disjoint {
                 original_start,
                 original_end,
-                operand_start: operand_start_value,
-                operand_end: operand_end_value,
-                strand: start_strand,
-            }));
-        }
+                operand_start,
+                operand_end,
+            } => Error::Clamp(ClampError::Disjoint {
+                original_start,
+                original_end,
+                operand_start,
+                operand_end,
+                strand,
+            }),
+            span::ClampError::DirectionMismatch { .. } => {
+                // SAFETY: intervals on one strand always have compatible span directions.
+                unreachable!()
+            }
+        })?;
 
         Ok(Self {
-            contig: start_contig,
-            strand: start_strand,
-            start: new_start,
-            end: new_end,
+            contig,
+            strand,
+            span,
         })
     }
 
@@ -986,7 +917,7 @@ where
     ///
     /// let start = Coordinate::<Interbase>::try_new("seq0", "+", 10)?;
     /// let end = Coordinate::<Interbase>::try_new("seq0", "+", 20)?;
-    /// let interval = Interval::try_new(start, end)?;
+    /// let interval = Interval::try_from((start, end))?;
     ///
     /// let query = Coordinate::<Interbase>::try_new("seq0", "+", 15)?;
     /// assert_eq!(interval.coordinate_offset(&query).unwrap(), 5);
@@ -1003,7 +934,7 @@ where
     ///
     /// let start = Coordinate::<Base>::try_new("seq0", "-", 20)?;
     /// let end = Coordinate::<Base>::try_new("seq0", "-", 10)?;
-    /// let interval = Interval::try_new(start, end)?;
+    /// let interval = Interval::try_from((start, end))?;
     ///
     /// let query = Coordinate::<Base>::try_new("seq0", "-", 15)?;
     /// assert_eq!(interval.coordinate_offset(&query).unwrap(), 5);
@@ -1017,15 +948,9 @@ where
     /// Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn coordinate_offset(&self, coordinate: &Coordinate<S>) -> Option<Number> {
-        if !self.contains_coordinate(coordinate) {
-            return None;
-        }
-
-        Some(
-            coordinate
-                .position()
-                .distance_unchecked(self.start().position()),
-        )
+        (self.contig() == coordinate.contig() && self.strand() == coordinate.strand())
+            .then(|| self.span.position_offset(coordinate.position()))
+            .flatten()
     }
 
     /// Returns the coordinate at the offset within the interval.
@@ -1100,12 +1025,9 @@ where
     /// Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn coordinate_at_offset(&self, offset: Number) -> Option<Coordinate<S>> {
-        let coordinate = self.start().into_owned().into_move_forward(offset)?;
-
-        match self.contains_coordinate(&coordinate) {
-            true => Some(coordinate),
-            false => None,
-        }
+        self.span
+            .position_at_offset(offset)
+            .map(|position| Coordinate::new(self.contig.clone(), self.strand, position))
     }
 
     /// Reverse complements the interval, meaning that:
@@ -1127,7 +1049,7 @@ where
     ///
     /// let start = Coordinate::<Interbase>::try_new("seq0", "+", 10)?;
     /// let end = Coordinate::<Interbase>::try_new("seq0", "+", 20)?;
-    /// let original = Interval::try_new(start, end)?;
+    /// let original = Interval::try_from((start, end))?;
     ///
     /// let complemented = original.clone().reverse_complement();
     /// assert_eq!(complemented, "seq0:-:20-10".parse::<Interval<Interbase>>()?);
@@ -1141,7 +1063,7 @@ where
     ///
     /// let start = Coordinate::<Base>::try_new("seq0", "+", 10)?;
     /// let end = Coordinate::<Base>::try_new("seq0", "+", 20)?;
-    /// let original = Interval::try_new(start, end)?;
+    /// let original = Interval::try_from((start, end))?;
     ///
     /// let complemented = original.clone().reverse_complement();
     /// assert_eq!(complemented, "seq0:-:20-10".parse::<Interval<Base>>()?);
@@ -1156,9 +1078,43 @@ where
         Self {
             contig: self.contig,
             strand: self.strand.complement(),
-            start: self.end,
-            end: self.start,
+            span: self.span.reversed(),
         }
+    }
+}
+
+impl<S: System> TryFrom<(Coordinate<S>, Coordinate<S>)> for Interval<S>
+where
+    Interval<S>: r#trait::Interval<S>,
+    Position<S>: position::r#trait::Position<S>,
+{
+    type Error = Error;
+
+    fn try_from((start, end): (Coordinate<S>, Coordinate<S>)) -> Result<Self> {
+        let (start_contig, start_strand, start_position) = start.into_parts();
+        let (end_contig, end_strand, end_position) = end.into_parts();
+
+        if start_contig != end_contig {
+            return Err(Error::Nonsensical(NonsensicalError::MismatchedContigs {
+                start: start_contig,
+                end: end_contig,
+            }));
+        }
+
+        if start_strand != end_strand {
+            return Err(Error::Nonsensical(NonsensicalError::MismatchedStrands {
+                start: start_strand,
+                end: end_strand,
+            }));
+        }
+
+        let strand = match start_strand {
+            Strand::Positive => "+",
+            Strand::Negative => "-",
+        };
+        let span = Span::from((start_position, end_position));
+
+        Self::try_new(start_contig.as_str(), strand, span)
     }
 }
 
@@ -1172,14 +1128,7 @@ where
     Position<S>: position::r#trait::Position<S>,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}:{}:{}-{}",
-            self.contig(),
-            self.strand(),
-            self.start().position(),
-            self.end().position(),
-        )
+        write!(f, "{}:{}:{}", self.contig(), self.strand(), self.span())
     }
 }
 
@@ -1208,22 +1157,20 @@ where
                 value: s.to_string(),
             })
         })?;
-
         let strand = strand.parse::<Strand>().map_err(Error::Strand)?;
-        let (start, end) = positions
-            .split_once(INTERVAL_SEPARATOR)
-            .filter(|(_, end)| !end.contains(INTERVAL_SEPARATOR))
-            .ok_or_else(|| ParseError::Format {
+        let strand = match strand {
+            Strand::Positive => "+",
+            Strand::Negative => "-",
+        };
+
+        let span = positions.parse::<Span<S>>().map_err(|error| match error {
+            span::ParseError::Format(_) => Error::Parse(ParseError::Format {
                 value: s.to_owned(),
-            })?;
+            }),
+            span::ParseError::Start(error) | span::ParseError::End(error) => Error::Position(error),
+        })?;
 
-        let start = start.parse::<Position<S>>().map_err(Error::Position)?;
-        let end = end.parse::<Position<S>>().map_err(Error::Position)?;
-
-        Interval::try_new(
-            Coordinate::new(contig.clone(), strand, start),
-            Coordinate::new(contig, strand, end),
-        )
+        Interval::try_new(contig.as_str(), strand, span)
     }
 }
 
@@ -1243,7 +1190,8 @@ mod tests {
         let start = "seq0:+:0".parse::<Coordinate<Interbase>>().unwrap();
         let end = "seq0:+:9".parse::<Coordinate<Interbase>>().unwrap();
 
-        let interval = Interval::try_new(start, end).unwrap();
+        // SAFETY: the endpoints share context and follow the positive strand.
+        let interval = Interval::try_from((start, end)).unwrap();
         assert_eq!(interval.count_entities(), 9);
     }
 
@@ -1252,7 +1200,7 @@ mod tests {
         let start = "seq0:+:0".parse::<Coordinate<Interbase>>().unwrap();
         let end = "seq1:+:10".parse::<Coordinate<Interbase>>().unwrap();
 
-        let err = Interval::try_new(start, end).unwrap_err();
+        let err = Interval::try_from((start, end)).unwrap_err();
         assert_eq!(
             err,
             Error::Nonsensical(NonsensicalError::MismatchedContigs {
@@ -1272,7 +1220,7 @@ mod tests {
         let start = "seq0:+:0".parse::<Coordinate<Interbase>>().unwrap();
         let end = "seq0:-:10".parse::<Coordinate<Interbase>>().unwrap();
 
-        let err = Interval::try_new(start, end).unwrap_err();
+        let err = Interval::try_from((start, end)).unwrap_err();
         assert_eq!(
             err,
             Error::Nonsensical(NonsensicalError::MismatchedStrands {
@@ -1296,21 +1244,19 @@ mod tests {
         let start = "seq0:+:10".parse::<Coordinate<Interbase>>().unwrap();
         let end = "seq0:+:0".parse::<Coordinate<Interbase>>().unwrap();
 
-        let err = Interval::try_new(start, end).unwrap_err();
+        let err = Interval::try_from((start, end)).unwrap_err();
 
         assert_eq!(
             err,
-            Error::Nonsensical(NonsensicalError::NegativelySized {
-                start: 10,
-                end: 0,
-                strand: Strand::Positive
-            })
+            Error::DirectionMismatch {
+                strand: Strand::Positive,
+                direction: Direction::Descending,
+            }
         );
 
         assert_eq!(
             err.to_string(),
-            "nonsensical interval: negatively sized interval: start is `10`, end is `0`, strand \
-             is `+`"
+            "span direction `descending` is incompatible with strand `+`"
         );
 
         //===================//
@@ -1320,21 +1266,19 @@ mod tests {
         let start = "seq0:-:0".parse::<Coordinate<Interbase>>().unwrap();
         let end = "seq0:-:10".parse::<Coordinate<Interbase>>().unwrap();
 
-        let err = Interval::try_new(start, end).unwrap_err();
+        let err = Interval::try_from((start, end)).unwrap_err();
 
         assert_eq!(
             err,
-            Error::Nonsensical(NonsensicalError::NegativelySized {
-                start: 0,
-                end: 10,
-                strand: Strand::Negative
-            })
+            Error::DirectionMismatch {
+                strand: Strand::Negative,
+                direction: Direction::Ascending,
+            }
         );
 
         assert_eq!(
             err.to_string(),
-            "nonsensical interval: negatively sized interval: start is `0`, end is `10`, strand \
-             is `-`"
+            "span direction `ascending` is incompatible with strand `-`"
         );
     }
 
@@ -1343,7 +1287,8 @@ mod tests {
         let start = "seq0:+:10".parse::<Coordinate<Interbase>>().unwrap();
         let end = "seq0:+:10".parse::<Coordinate<Interbase>>().unwrap();
 
-        let interval = Interval::try_new(start.clone(), end.clone()).unwrap();
+        // SAFETY: stationary spans are valid on the positive strand.
+        let interval = Interval::try_from((start.clone(), end.clone())).unwrap();
         assert!(interval.end().position().get() - interval.start().position().get() == 0);
         assert!(interval.contains_coordinate(&start));
         assert!(interval.contains_coordinate(&end));
@@ -1367,7 +1312,7 @@ mod tests {
     fn endpoint_views_borrow_interval_data() -> Result<()> {
         let start = Coordinate::<Interbase>::try_new("seq0", "+", 10)?;
         let end = Coordinate::<Interbase>::try_new("seq0", "+", 20)?;
-        let interval = Interval::try_new(start.clone(), end.clone())?;
+        let interval = Interval::try_from((start.clone(), end.clone()))?;
 
         let start_ref: CoordinateRef<'_, Interbase> = interval.start();
         let end_ref: CoordinateRef<'_, Interbase> = interval.end();
@@ -1677,7 +1622,7 @@ mod tests {
     fn contig_with_colons_round_trips() -> Result<()> {
         let start = Coordinate::<Interbase>::try_new("assembly:chr:1", "+", 10)?;
         let end = Coordinate::<Interbase>::try_new("assembly:chr:1", "+", 20)?;
-        let interval = Interval::try_new(start, end)?;
+        let interval = Interval::try_from((start, end))?;
         let parsed = interval.to_string().parse::<Interval<Interbase>>()?;
 
         assert_eq!(parsed, interval);
@@ -1761,14 +1706,16 @@ mod tests {
         // Positive-stranded interval
         let start = "seq0:+:0".parse::<Coordinate<Interbase>>().unwrap();
         let end = "seq0:+:10".parse::<Coordinate<Interbase>>().unwrap();
-        let interval = Interval::try_new(start, end).unwrap();
+        // SAFETY: the endpoints share context and follow the positive strand.
+        let interval = Interval::try_from((start, end)).unwrap();
 
         assert_eq!(interval.to_string(), "seq0:+:0-10");
 
         // Negative-stranded interval
         let start = "seq0:-:10".parse::<Coordinate<Interbase>>().unwrap();
         let end = "seq0:-:0".parse::<Coordinate<Interbase>>().unwrap();
-        let interval = Interval::try_new(start, end).unwrap();
+        // SAFETY: the endpoints share context and follow the negative strand.
+        let interval = Interval::try_from((start, end)).unwrap();
 
         assert_eq!(interval.to_string(), "seq0:-:10-0");
     }

--- a/omics-coordinate/src/interval.rs
+++ b/omics-coordinate/src/interval.rs
@@ -1243,7 +1243,7 @@ mod tests {
     }
 
     #[test]
-    fn nonsensical_start_greater_than_end() {
+    fn direction_mismatch_when_endpoints_conflict_with_strand() {
         //===================//
         // Positive stranded //
         //===================//

--- a/omics-coordinate/src/interval.rs
+++ b/omics-coordinate/src/interval.rs
@@ -221,6 +221,10 @@ where
 {
     /// Creates an interval from genomic context and a directed span.
     ///
+    /// Build the [`Span`] first when your geometry is context free. Use
+    /// `Interval::try_from((start, end))` when you already have localized
+    /// coordinates.
+    ///
     /// Positive strands accept ascending and stationary spans. Negative
     /// strands accept descending and stationary spans.
     ///
@@ -234,11 +238,14 @@ where
     /// ```
     /// use omics_coordinate::Interval;
     /// use omics_coordinate::Span;
+    /// use omics_coordinate::span::Direction;
     /// use omics_coordinate::system::Interbase;
     ///
-    /// let span = Span::<Interbase>::try_new(10, 20)?;
-    /// let interval = Interval::try_new("seq0", "+", span)?;
-    /// assert_eq!(interval.to_string(), "seq0:+:10-20");
+    /// let span = Span::<Interbase>::try_new(20, 10)?;
+    /// assert_eq!(span.direction(), Direction::Descending);
+    ///
+    /// let interval = Interval::try_new("seq0", "-", span)?;
+    /// assert_eq!(interval.to_string(), "seq0:-:20-10");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```

--- a/omics-coordinate/src/interval/base.rs
+++ b/omics-coordinate/src/interval/base.rs
@@ -3,6 +3,7 @@
 use crate::base::Coordinate;
 use crate::interval::r#trait;
 use crate::position::Number;
+use crate::span::Span;
 use crate::system::Base;
 use crate::system::Interbase;
 
@@ -36,14 +37,22 @@ impl Interval {
     pub fn into_equivalent_interbase(self) -> crate::interval::Interval<Interbase> {
         let (start, end) = self.into_coordinates();
 
-        // SAFETY: given the rules of how interbase and base coordinate systems
-        // work, this should always unwrap.
+        // SAFETY: every valid base interval endpoint has the required interbase
+        // boundary.
         let start = start.nudge_backward().unwrap();
+        // SAFETY: every valid base interval endpoint has the required interbase
+        // boundary.
         let end = end.nudge_forward().unwrap();
+        let (contig, strand, start) = start.into_parts();
+        let (_, _, end) = end.into_parts();
+        let span = Span::from((start, end));
+        let strand = match strand {
+            crate::Strand::Positive => "+",
+            crate::Strand::Negative => "-",
+        };
 
-        // SAFETY: since this was previously a valid interbase interval, as long
-        // as the two nudges above succeed, this should always unwrap.
-        crate::interval::Interval::<Interbase>::try_new(start, end).unwrap()
+        // SAFETY: the converted span retains the direction required by the strand.
+        crate::interval::Interval::<Interbase>::try_new(contig.as_str(), strand, span).unwrap()
     }
 }
 
@@ -53,19 +62,14 @@ impl Interval {
 
 impl r#trait::Interval<Base> for Interval {
     fn contains_entity(&self, coordinate: &Coordinate) -> bool {
-        // NOTE: for in-base positions whether or not the entity is contained in
-        // the interval matches the implementation of whether or not the
-        // coordinate is contained within the interval, as entities and
-        // coordinates are essentially the same thing in this system.
-        self.contains_coordinate(coordinate)
+        self.contig() == coordinate.contig()
+            && self.strand() == coordinate.strand()
+            && self.span().contains_entity(coordinate.position())
     }
 
     /// Gets the number of entities within the interval.
     fn count_entities(&self) -> Number {
-        self.start()
-            .position()
-            .distance_unchecked(self.end().position())
-            + 1
+        self.span().count_entities()
     }
 }
 
@@ -80,11 +84,13 @@ mod tests {
     }
 
     fn create_interval(contig: &str, strand: &str, start: Number, end: Number) -> Interval {
-        Interval::try_new(
+        let interval = Interval::try_from((
             create_coordinate(contig, strand, start),
             create_coordinate(contig, strand, end),
-        )
-        .unwrap()
+        ));
+        // SAFETY: the test helper receives endpoints compatible with the requested
+        // strand.
+        interval.unwrap()
     }
 
     #[test]

--- a/omics-coordinate/src/interval/interbase.rs
+++ b/omics-coordinate/src/interval/interbase.rs
@@ -1,10 +1,10 @@
 //! Interbase intervals.
 
-use crate::Strand;
 use crate::base;
 use crate::interbase::Coordinate;
 use crate::interval::Number;
 use crate::interval::r#trait;
+use crate::span::Span;
 use crate::system::Base;
 use crate::system::Interbase;
 
@@ -147,8 +147,15 @@ impl Interval {
 
         let start = start.nudge_forward()?;
         let end = end.nudge_backward()?;
+        let (contig, strand, start) = start.into_parts();
+        let (_, _, end) = end.into_parts();
+        let span = Span::from((start, end));
+        let strand = match strand {
+            crate::Strand::Positive => "+",
+            crate::Strand::Negative => "-",
+        };
 
-        crate::interval::Interval::<Base>::try_new(start, end).ok()
+        crate::interval::Interval::<Base>::try_new(contig.as_str(), strand, span).ok()
     }
 }
 
@@ -158,31 +165,14 @@ impl Interval {
 
 impl r#trait::Interval<Interbase> for Interval {
     fn contains_entity(&self, coordinate: &base::Coordinate) -> bool {
-        if self.contig() != coordinate.contig() {
-            return false;
-        }
-
-        if self.strand() != coordinate.strand() {
-            return false;
-        }
-
-        match self.strand() {
-            Strand::Positive => {
-                self.start().position().get() < coordinate.position().get()
-                    && self.end().position().get() >= coordinate.position().get()
-            }
-            Strand::Negative => {
-                self.start().position().get() >= coordinate.position().get()
-                    && self.end().position().get() < coordinate.position().get()
-            }
-        }
+        self.contig() == coordinate.contig()
+            && self.strand() == coordinate.strand()
+            && self.span().contains_entity(coordinate.position())
     }
 
     /// Gets the number of entities within the interval.
     fn count_entities(&self) -> Number {
-        self.start()
-            .position()
-            .distance_unchecked(self.end().position())
+        self.span().count_entities()
     }
 }
 
@@ -209,11 +199,13 @@ mod tests {
     }
 
     fn create_interval(contig: &str, strand: &str, start: Number, end: Number) -> Interval {
-        Interval::try_new(
+        let interval = Interval::try_from((
             create_coordinate(contig, strand, start),
             create_coordinate(contig, strand, end),
-        )
-        .unwrap()
+        ));
+        // SAFETY: the test helper receives endpoints compatible with the requested
+        // strand.
+        interval.unwrap()
     }
 
     #[test]

--- a/omics-coordinate/src/lib.rs
+++ b/omics-coordinate/src/lib.rs
@@ -21,7 +21,8 @@
 //! * A [`Coordinate`] localizes a position to a contig and, when present, a
 //!   strand.
 //! * A [`Span`] stores directed geometry between two positions without contig
-//!   or strand context.
+//!   or strand context. `Span<S>` preserves the supplied endpoint order and
+//!   derives [`Direction`](crate::span::Direction) by comparing start and end.
 //! * An [`Interval`] localizes a span by adding contig and strand metadata.
 //!
 //! Coordinates, via their positions, can fall within the _interbase_ coordinate

--- a/omics-coordinate/src/lib.rs
+++ b/omics-coordinate/src/lib.rs
@@ -15,6 +15,15 @@
 //! * Optionally, if the molecule is stranded, the strand upon which the
 //!   coordinate sits is known as the [**strand**](crate::Strand).
 //!
+//! The crate layers these ideas into four related types.
+//!
+//! * A [`Position`] is a typed offset within one coordinate system.
+//! * A [`Coordinate`] localizes a position to a contig and, when present, a
+//!   strand.
+//! * A [`Span`] stores directed geometry between two positions without contig
+//!   or strand context.
+//! * An [`Interval`] localizes a span by adding contig and strand metadata.
+//!
 //! Coordinates, via their positions, can fall within the _interbase_ coordinate
 //! system (which is closely related to the 0-based, half-open coordinate
 //! system) or the _in-base_ coordinate system (closely related to the 1-based,
@@ -77,6 +86,35 @@
 //!
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
+//!
+//! When you need geometry before you know its genomic context, build a
+//! [`Span`] first and localize it later with an [`Interval`].
+//!
+//! ```
+//! use omics_coordinate::Interval;
+//! use omics_coordinate::Span;
+//! use omics_coordinate::span::Direction;
+//! use omics_coordinate::system::Interbase;
+//!
+//! let ascending = Span::<Interbase>::try_new(10, 20)?;
+//! assert_eq!(ascending.direction(), Direction::Ascending);
+//! assert!(!ascending.is_empty());
+//!
+//! let empty = Span::<Interbase>::try_new(10, 10)?;
+//! assert!(empty.is_empty());
+//!
+//! let descending = Span::<Interbase>::try_new(20, 10)?;
+//! assert_eq!(descending.direction(), Direction::Descending);
+//!
+//! let interval = Interval::try_new("seq0", "-", descending)?;
+//! assert_eq!(interval.to_string(), "seq0:-:20-10");
+//!
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! Empty interbase spans are valid because they represent events at a boundary
+//! between entities. Insertions and breakends happen at one interbase position
+//! even when they cover no in-base entity.
 //!
 //! # Background
 //!
@@ -374,12 +412,18 @@
 //!   lost during any conversion from one to the other. If it is of interest,
 //!   you may keep track of this kind of thing on your own at conversion time.
 //!
-//! ## Intervals
+//! ## Spans and Intervals
 //!
-//! Intervals describe a range of positions upon a contiguous molecule.
-//! Generally speaking, you can think of an interval as simply a start
-//! coordinate and end coordinate within one of the coordinate systems.
-//! Intervals are always closed _with respect to their comprising coordinates_.
+//! A [`Span`] describes directed geometry between two positions in one
+//! coordinate system. Spans are context free. They do not name a contig or
+//! strand, so you can reuse the same geometry until you are ready to localize
+//! it.
+//!
+//! An [`Interval`] localizes a span to a contiguous molecule by attaching a
+//! contig and strand. Intervals are always closed _with respect to their
+//! comprising coordinates_. When you already have localized endpoints,
+//! `Interval::try_from((start, end))` builds the span and validates that both
+//! coordinates share the same genomic context.
 //!
 //! The following figure illustrates this concept using the notation described
 //! in [the position section of the docs](#positions).

--- a/omics-coordinate/src/lib.rs
+++ b/omics-coordinate/src/lib.rs
@@ -458,6 +458,7 @@ pub mod coordinate;
 pub mod interval;
 pub mod math;
 pub mod position;
+pub mod span;
 pub mod strand;
 pub mod system;
 
@@ -468,5 +469,6 @@ pub use coordinate::base;
 pub use coordinate::interbase;
 pub use interval::Interval;
 pub use position::Position;
+pub use span::Span;
 pub use strand::Strand;
 pub use system::System;

--- a/omics-coordinate/src/span.rs
+++ b/omics-coordinate/src/span.rs
@@ -185,7 +185,7 @@ pub struct Span<S: System> {
 
 impl<S: System> Span<S>
 where
-    Position<S>: position::r#trait::Position<S> + r#trait::PositionForSpan<S>,
+    Position<S>: r#trait::PositionForSpan<S>,
 {
     /// Creates a span from start and end numbers.
     pub fn try_new(start: Number, end: Number) -> Result<Self> {
@@ -196,7 +196,12 @@ where
 
         Ok(Self { start, end })
     }
+}
 
+impl<S: System> Span<S>
+where
+    Position<S>: position::r#trait::Position<S>,
+{
     /// Returns the start position.
     pub fn start(&self) -> &Position<S> {
         &self.start

--- a/omics-coordinate/src/span.rs
+++ b/omics-coordinate/src/span.rs
@@ -1,0 +1,218 @@
+//! Span values.
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::str::FromStr;
+
+use thiserror::Error;
+
+use crate::Position;
+use crate::System;
+use crate::position;
+use crate::position::Number;
+use crate::system::Base;
+use crate::system::Interbase;
+
+pub mod base;
+pub mod interbase;
+
+/// The separator between a span start and end position.
+const SPAN_SEPARATOR: &str = "-";
+
+/// A direction along a coordinate system.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Direction {
+    /// The end lies after the start.
+    Ascending,
+
+    /// The endpoints are equal.
+    Stationary,
+
+    /// The end lies before the start.
+    Descending,
+}
+
+/// An error from building a span from raw numbers.
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum Error {
+    /// The start position is invalid.
+    #[error("invalid span start position")]
+    Start(#[source] position::Error),
+
+    /// The end position is invalid.
+    #[error("invalid span end position")]
+    End(#[source] position::Error),
+}
+
+/// A result with a span construction error.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// An error from parsing a span string.
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum ParseError {
+    /// The string does not have the expected shape.
+    #[error("invalid span format `{0}`")]
+    Format(String),
+
+    /// The start position is invalid.
+    #[error("invalid span start position")]
+    Start(#[source] position::Error),
+
+    /// The end position is invalid.
+    #[error("invalid span end position")]
+    End(#[source] position::Error),
+}
+
+/// A result with a span parsing error.
+pub type ParseResult<T> = std::result::Result<T, ParseError>;
+
+mod r#trait {
+    use super::*;
+
+    pub trait PositionForSpan<S: System> {
+        fn try_new_position(value: Number) -> std::result::Result<Position<S>, position::Error>;
+    }
+
+    pub trait Span<S: System> {
+        fn contains_entity(&self, position: &Position<Base>) -> bool;
+
+        fn count_entities(&self) -> Number;
+
+        fn is_empty(&self) -> bool;
+    }
+}
+
+impl r#trait::PositionForSpan<Base> for Position<Base> {
+    fn try_new_position(value: Number) -> std::result::Result<Position<Base>, position::Error> {
+        Position::<Base>::try_new(value)
+    }
+}
+
+impl r#trait::PositionForSpan<Interbase> for Position<Interbase> {
+    fn try_new_position(
+        value: Number,
+    ) -> std::result::Result<Position<Interbase>, position::Error> {
+        Ok(Position::<Interbase>::new(value))
+    }
+}
+
+/// A span with a typed coordinate system.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Span<S: System> {
+    start: Position<S>,
+    end: Position<S>,
+}
+
+impl<S: System> Span<S>
+where
+    Position<S>: position::r#trait::Position<S> + r#trait::PositionForSpan<S>,
+{
+    /// Creates a span from start and end numbers.
+    pub fn try_new(start: Number, end: Number) -> Result<Self> {
+        let start = <Position<S> as r#trait::PositionForSpan<S>>::try_new_position(start)
+            .map_err(Error::Start)?;
+        let end = <Position<S> as r#trait::PositionForSpan<S>>::try_new_position(end)
+            .map_err(Error::End)?;
+
+        Ok(Self { start, end })
+    }
+
+    /// Returns the start position.
+    pub fn start(&self) -> &Position<S> {
+        &self.start
+    }
+
+    /// Returns the end position.
+    pub fn end(&self) -> &Position<S> {
+        &self.end
+    }
+
+    /// Consumes the span into both positions.
+    pub fn into_positions(self) -> (Position<S>, Position<S>) {
+        (self.start, self.end)
+    }
+
+    /// Returns the direction from start to end.
+    pub fn direction(&self) -> Direction {
+        match self.start.cmp(&self.end) {
+            Ordering::Less => Direction::Ascending,
+            Ordering::Equal => Direction::Stationary,
+            Ordering::Greater => Direction::Descending,
+        }
+    }
+
+    /// Returns a span with swapped endpoints.
+    #[must_use = "this method returns a new span"]
+    pub fn reversed(self) -> Self {
+        let (start, end) = self.into_positions();
+
+        Self {
+            start: end,
+            end: start,
+        }
+    }
+
+    /// Returns whether the span contains the given position.
+    pub fn contains_position(&self, position: &Position<S>) -> bool {
+        match self.direction() {
+            Direction::Ascending => self.start <= *position && *position <= self.end,
+            Direction::Stationary => self.start == *position,
+            Direction::Descending => self.end <= *position && *position <= self.start,
+        }
+    }
+}
+
+impl<S: System> Span<S>
+where
+    Span<S>: r#trait::Span<S>,
+    Position<S>: position::r#trait::Position<S>,
+{
+    /// Returns whether the span contains the given entity.
+    pub fn contains_entity(&self, position: &Position<Base>) -> bool {
+        <Self as r#trait::Span<S>>::contains_entity(self, position)
+    }
+
+    /// Counts the entities contained in the span.
+    pub fn count_entities(&self) -> Number {
+        <Self as r#trait::Span<S>>::count_entities(self)
+    }
+
+    /// Returns whether the span contains no entities.
+    pub fn is_empty(&self) -> bool {
+        <Self as r#trait::Span<S>>::is_empty(self)
+    }
+}
+
+impl<S: System> From<(Position<S>, Position<S>)> for Span<S> {
+    fn from((start, end): (Position<S>, Position<S>)) -> Self {
+        Self { start, end }
+    }
+}
+
+impl<S: System> fmt::Display for Span<S>
+where
+    Position<S>: position::r#trait::Position<S>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}-{}", self.start, self.end)
+    }
+}
+
+impl<S: System> FromStr for Span<S>
+where
+    Position<S>: position::r#trait::Position<S>,
+{
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> ParseResult<Self> {
+        let (start, end) = s
+            .split_once(SPAN_SEPARATOR)
+            .filter(|(_, end)| !end.contains(SPAN_SEPARATOR))
+            .ok_or_else(|| ParseError::Format(s.to_owned()))?;
+
+        let start = start.parse::<Position<S>>().map_err(ParseError::Start)?;
+        let end = end.parse::<Position<S>>().map_err(ParseError::End)?;
+
+        Ok(Self { start, end })
+    }
+}

--- a/omics-coordinate/src/span.rs
+++ b/omics-coordinate/src/span.rs
@@ -1,6 +1,8 @@
 //! Span values.
 
 use std::cmp::Ordering;
+use std::cmp::max;
+use std::cmp::min;
 use std::fmt;
 use std::str::FromStr;
 
@@ -31,6 +33,74 @@ pub enum Direction {
     /// The end lies before the start.
     Descending,
 }
+
+impl Direction {
+    /// Returns whether two directions can be clamped together.
+    pub(crate) fn is_compatible(self, other: Self) -> bool {
+        self == other || self == Self::Stationary || other == Self::Stationary
+    }
+}
+
+impl fmt::Display for Direction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::Ascending => "ascending",
+            Self::Stationary => "stationary",
+            Self::Descending => "descending",
+        };
+
+        f.write_str(value)
+    }
+}
+
+/// An error from clamping one span by another.
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum ClampError {
+    /// The spans move in incompatible directions.
+    #[error(
+        "direction mismatch between spans `{original_start}-{original_end}` and \
+         `{operand_start}-{operand_end}`; directions are `{original_direction}` and \
+         `{operand_direction}`"
+    )]
+    DirectionMismatch {
+        /// The start position of the original span.
+        original_start: Number,
+
+        /// The end position of the original span.
+        original_end: Number,
+
+        /// The direction of the original span.
+        original_direction: Direction,
+
+        /// The start position of the operand span.
+        operand_start: Number,
+
+        /// The end position of the operand span.
+        operand_end: Number,
+
+        /// The direction of the operand span.
+        operand_direction: Direction,
+    },
+
+    /// The spans do not overlap.
+    #[error("disjoint spans `{original_start}-{original_end}` and `{operand_start}-{operand_end}`")]
+    Disjoint {
+        /// The start position of the original span.
+        original_start: Number,
+
+        /// The end position of the original span.
+        original_end: Number,
+
+        /// The start position of the operand span.
+        operand_start: Number,
+
+        /// The end position of the operand span.
+        operand_end: Number,
+    },
+}
+
+/// A result with a span clamping error.
+pub type ClampResult<T> = std::result::Result<T, ClampError>;
 
 /// An error from building a span from raw numbers.
 #[derive(Error, Debug, PartialEq, Eq)]
@@ -169,6 +239,67 @@ where
             Direction::Stationary => self.start == *position,
             Direction::Descending => self.end <= *position && *position <= self.start,
         }
+    }
+
+    /// Returns the offset of a position from the start of the span.
+    pub fn position_offset(&self, position: &Position<S>) -> Option<Number> {
+        self.contains_position(position)
+            .then(|| self.start.distance_unchecked(position))
+    }
+
+    /// Returns the position at an offset from the start of the span.
+    pub fn position_at_offset(&self, offset: Number) -> Option<Position<S>> {
+        let position = match self.direction() {
+            Direction::Ascending => self.start.checked_add(offset)?,
+            Direction::Stationary if offset == 0 => self.start.clone(),
+            Direction::Stationary => return None,
+            Direction::Descending => self.start.checked_sub(offset)?,
+        };
+
+        self.contains_position(&position).then_some(position)
+    }
+
+    /// Clamps this span by another span.
+    #[must_use = "this method returns a new span"]
+    pub fn clamp(self, operand: Self) -> ClampResult<Self> {
+        let original_direction = self.direction();
+        let operand_direction = operand.direction();
+        let original_start = self.start.get();
+        let original_end = self.end.get();
+        let operand_start = operand.start.get();
+        let operand_end = operand.end.get();
+
+        if !original_direction.is_compatible(operand_direction) {
+            return Err(ClampError::DirectionMismatch {
+                original_start,
+                original_end,
+                original_direction,
+                operand_start,
+                operand_end,
+                operand_direction,
+            });
+        }
+
+        let lower = max(
+            min(self.start.clone(), self.end.clone()),
+            min(operand.start.clone(), operand.end.clone()),
+        );
+        let upper = min(max(self.start, self.end), max(operand.start, operand.end));
+
+        if lower > upper {
+            return Err(ClampError::Disjoint {
+                original_start,
+                original_end,
+                operand_start,
+                operand_end,
+            });
+        }
+
+        Ok(match original_direction {
+            Direction::Ascending => Self::from((lower, upper)),
+            Direction::Stationary => Self::from((lower, upper)),
+            Direction::Descending => Self::from((upper, lower)),
+        })
     }
 }
 

--- a/omics-coordinate/src/span.rs
+++ b/omics-coordinate/src/span.rs
@@ -66,18 +66,26 @@ pub enum ParseError {
 /// A result with a span parsing error.
 pub type ParseResult<T> = std::result::Result<T, ParseError>;
 
+/// Internal trait definitions for span operations.
 mod r#trait {
     use super::*;
 
+    /// Trait for creating positions from numeric values within coordinate
+    /// systems.
     pub trait PositionForSpan<S: System> {
+        /// Creates a new position from a numeric value.
         fn try_new_position(value: Number) -> std::result::Result<Position<S>, position::Error>;
     }
 
+    /// Trait for coordinate span operations.
     pub trait Span<S: System> {
+        /// Tests whether this span contains an entity at the given position.
         fn contains_entity(&self, position: &Position<Base>) -> bool;
 
+        /// Returns the count of entities in this span.
         fn count_entities(&self) -> Number;
 
+        /// Tests whether this span contains no entities.
         fn is_empty(&self) -> bool;
     }
 }
@@ -99,7 +107,9 @@ impl r#trait::PositionForSpan<Interbase> for Position<Interbase> {
 /// A span with a typed coordinate system.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Span<S: System> {
+    /// The start position of this span.
     start: Position<S>,
+    /// The end position of this span.
     end: Position<S>,
 }
 

--- a/omics-coordinate/src/span/base.rs
+++ b/omics-coordinate/src/span/base.rs
@@ -1,0 +1,22 @@
+//! Base spans.
+
+use crate::Position;
+use crate::position::Number;
+use crate::system::Base;
+
+/// A base span.
+pub type Span = crate::Span<Base>;
+
+impl super::r#trait::Span<Base> for Span {
+    fn contains_entity(&self, position: &Position<Base>) -> bool {
+        self.contains_position(position)
+    }
+
+    fn count_entities(&self) -> Number {
+        self.start().distance_unchecked(self.end()) + 1
+    }
+
+    fn is_empty(&self) -> bool {
+        false
+    }
+}

--- a/omics-coordinate/src/span/interbase.rs
+++ b/omics-coordinate/src/span/interbase.rs
@@ -1,0 +1,32 @@
+//! Interbase spans.
+
+use crate::Position;
+use crate::position::Number;
+use crate::span::Direction;
+use crate::system::Base;
+use crate::system::Interbase;
+
+/// An interbase span.
+pub type Span = crate::Span<Interbase>;
+
+impl super::r#trait::Span<Interbase> for Span {
+    fn contains_entity(&self, position: &Position<Base>) -> bool {
+        match self.direction() {
+            Direction::Ascending => {
+                self.start().get() < position.get() && position.get() <= self.end().get()
+            }
+            Direction::Stationary => false,
+            Direction::Descending => {
+                self.end().get() < position.get() && position.get() <= self.start().get()
+            }
+        }
+    }
+
+    fn count_entities(&self) -> Number {
+        self.start().distance_unchecked(self.end())
+    }
+
+    fn is_empty(&self) -> bool {
+        self.start() == self.end()
+    }
+}

--- a/omics-coordinate/tests/spans.rs
+++ b/omics-coordinate/tests/spans.rs
@@ -2,6 +2,7 @@
 
 use omics_coordinate::Position;
 use omics_coordinate::Span;
+use omics_coordinate::span::ClampError;
 use omics_coordinate::span::Direction;
 use omics_coordinate::system::Base;
 use omics_coordinate::system::Interbase;
@@ -124,6 +125,114 @@ fn exposes_system_aliases() -> Result<(), Box<dyn std::error::Error>> {
 
     assert_eq!(base.start().get(), 10);
     assert_eq!(interbase.end().get(), 12);
+
+    Ok(())
+}
+
+#[test]
+fn resolves_offsets_in_traversal_direction() -> Result<(), Box<dyn std::error::Error>> {
+    let ascending = Span::<Interbase>::try_new(10, 20)?;
+    let descending = Span::<Interbase>::try_new(20, 10)?;
+
+    assert_eq!(ascending.position_offset(&Position::new(15)), Some(5));
+    assert_eq!(descending.position_offset(&Position::new(15)), Some(5));
+    assert_eq!(ascending.position_offset(&Position::new(9)), None);
+    assert_eq!(descending.position_offset(&Position::new(21)), None);
+    assert_eq!(ascending.position_at_offset(5), Some(Position::new(15)));
+    assert_eq!(descending.position_at_offset(5), Some(Position::new(15)));
+    assert_eq!(descending.position_at_offset(11), None);
+
+    Ok(())
+}
+
+#[test]
+fn clamps_same_direction_overlaps() -> Result<(), Box<dyn std::error::Error>> {
+    let ascending = Span::<Interbase>::try_new(10, 20)?;
+    let ascending_operand = Span::<Interbase>::try_new(15, 25)?;
+    let descending = Span::<Interbase>::try_new(20, 10)?;
+    let descending_operand = Span::<Interbase>::try_new(18, 8)?;
+
+    assert_eq!(
+        ascending.clamp(ascending_operand)?,
+        Span::<Interbase>::try_new(15, 20)?
+    );
+    assert_eq!(
+        descending.clamp(descending_operand)?,
+        Span::<Interbase>::try_new(18, 10)?
+    );
+
+    Ok(())
+}
+
+#[test]
+fn clamps_stationary_spans_against_either_direction() -> Result<(), Box<dyn std::error::Error>> {
+    let point = Span::<Interbase>::try_new(15, 15)?;
+    let ascending = Span::<Interbase>::try_new(10, 20)?;
+    let descending = Span::<Interbase>::try_new(20, 10)?;
+
+    assert_eq!(point.clone().clamp(ascending)?, point);
+    assert_eq!(point.clone().clamp(descending)?, point);
+
+    Ok(())
+}
+
+#[test]
+fn clamps_when_operand_is_stationary() -> Result<(), Box<dyn std::error::Error>> {
+    let point = Span::<Interbase>::try_new(15, 15)?;
+    let ascending = Span::<Interbase>::try_new(10, 20)?;
+    let descending = Span::<Interbase>::try_new(20, 10)?;
+
+    assert_eq!(ascending.clamp(point.clone())?, point);
+    assert_eq!(descending.clamp(point.clone())?, point);
+
+    Ok(())
+}
+
+#[test]
+fn rejects_disjoint_spans() -> Result<(), Box<dyn std::error::Error>> {
+    let ascending = Span::<Interbase>::try_new(10, 20)?;
+    let operand = Span::<Interbase>::try_new(21, 30)?;
+
+    assert_eq!(
+        ascending.clamp(operand).unwrap_err(),
+        ClampError::Disjoint {
+            original_start: 10,
+            original_end: 20,
+            operand_start: 21,
+            operand_end: 30,
+        }
+    );
+
+    Ok(())
+}
+
+#[test]
+fn rejects_incompatible_directions() -> Result<(), Box<dyn std::error::Error>> {
+    let ascending = Span::<Interbase>::try_new(10, 20)?;
+    let descending = Span::<Interbase>::try_new(20, 10)?;
+
+    assert_eq!(
+        ascending.clone().clamp(descending.clone()).unwrap_err(),
+        ClampError::DirectionMismatch {
+            original_start: 10,
+            original_end: 20,
+            original_direction: Direction::Ascending,
+            operand_start: 20,
+            operand_end: 10,
+            operand_direction: Direction::Descending,
+        }
+    );
+    assert_eq!(
+        descending.clamp(ascending).unwrap_err(),
+        ClampError::DirectionMismatch {
+            original_start: 20,
+            original_end: 10,
+            original_direction: Direction::Descending,
+            operand_start: 10,
+            operand_end: 20,
+            operand_direction: Direction::Ascending,
+        }
+    );
 
     Ok(())
 }

--- a/omics-coordinate/tests/spans.rs
+++ b/omics-coordinate/tests/spans.rs
@@ -1,7 +1,11 @@
 #![expect(missing_docs, reason = "integration tests do not need crate docs")]
 
+use omics_coordinate::Coordinate;
+use omics_coordinate::Interval;
 use omics_coordinate::Position;
 use omics_coordinate::Span;
+use omics_coordinate::Strand;
+use omics_coordinate::interval;
 use omics_coordinate::span::ClampError;
 use omics_coordinate::span::Direction;
 use omics_coordinate::system::Base;
@@ -233,6 +237,157 @@ fn rejects_incompatible_directions() -> Result<(), Box<dyn std::error::Error>> {
             operand_direction: Direction::Ascending,
         }
     );
+
+    Ok(())
+}
+
+#[test]
+fn localizes_spans_with_compatible_strands() -> Result<(), Box<dyn std::error::Error>> {
+    let ascending = Span::<Interbase>::try_new(10, 20)?;
+    let positive = Interval::try_new("seq0", "+", ascending.clone())?;
+
+    assert_eq!(positive.contig().as_str(), "seq0");
+    assert_eq!(positive.strand(), Strand::Positive);
+    assert_eq!(positive.span(), &ascending);
+
+    let descending = ascending.reversed();
+    let negative = Interval::try_new("seq0", "-", descending.clone())?;
+
+    assert_eq!(negative.strand(), Strand::Negative);
+    assert_eq!(negative.span(), &descending);
+
+    Ok(())
+}
+
+#[test]
+fn rejects_direction_and_strand_mismatches() -> Result<(), Box<dyn std::error::Error>> {
+    let ascending = Span::<Interbase>::try_new(10, 20)?;
+    let descending = ascending.clone().reversed();
+
+    assert_eq!(
+        Interval::try_new("seq0", "-", ascending).unwrap_err(),
+        interval::Error::DirectionMismatch {
+            strand: Strand::Negative,
+            direction: Direction::Ascending,
+        }
+    );
+    assert_eq!(
+        Interval::try_new("seq0", "+", descending).unwrap_err(),
+        interval::Error::DirectionMismatch {
+            strand: Strand::Positive,
+            direction: Direction::Descending,
+        }
+    );
+
+    Ok(())
+}
+
+#[test]
+fn accepts_stationary_spans_on_both_strands() -> Result<(), Box<dyn std::error::Error>> {
+    let span = Span::<Interbase>::try_new(10, 10)?;
+    let positive = Interval::try_new("seq0", "+", span.clone())?;
+    let negative = Interval::try_new("seq0", "-", span.clone())?;
+
+    assert_eq!(positive.span(), &span);
+    assert_eq!(negative.span(), &span);
+
+    Ok(())
+}
+
+#[test]
+fn converts_coordinate_pairs() -> Result<(), Box<dyn std::error::Error>> {
+    let start = Coordinate::<Interbase>::try_new("seq0", "+", 10)?;
+    let end = Coordinate::<Interbase>::try_new("seq0", "+", 20)?;
+    let interval = Interval::try_from((start, end))?;
+
+    assert_eq!(interval.span().to_string(), "10-20");
+
+    Ok(())
+}
+
+#[test]
+fn rejects_coordinate_pairs_with_mismatched_context() -> Result<(), Box<dyn std::error::Error>> {
+    let start = Coordinate::<Interbase>::try_new("seq0", "+", 10)?;
+    let other_contig = Coordinate::<Interbase>::try_new("seq1", "+", 20)?;
+    let other_strand = Coordinate::<Interbase>::try_new("seq0", "-", 10)?;
+
+    assert!(matches!(
+        Interval::try_from((start.clone(), other_contig)),
+        Err(interval::Error::Nonsensical(
+            interval::NonsensicalError::MismatchedContigs { .. }
+        ))
+    ));
+    assert!(matches!(
+        Interval::try_from((start, other_strand)),
+        Err(interval::Error::Nonsensical(
+            interval::NonsensicalError::MismatchedStrands { .. }
+        ))
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn consumes_interval_into_span() -> Result<(), Box<dyn std::error::Error>> {
+    let span = Span::<Interbase>::try_new(10, 20)?;
+    let interval = Interval::try_new("seq0", "+", span.clone())?;
+
+    assert_eq!(interval.into_span(), span);
+
+    Ok(())
+}
+
+#[test]
+fn interval_strings_round_trip_with_colon_contigs() -> Result<(), Box<dyn std::error::Error>> {
+    for value in ["seq0:+:10-20", "assembly:chr:1:-:20-10"] {
+        let interval = value.parse::<Interval<Interbase>>()?;
+
+        assert_eq!(interval.to_string(), value);
+        assert_eq!(
+            interval.to_string().parse::<Interval<Interbase>>()?,
+            interval
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn delegates_geometry_to_spans() -> Result<(), Box<dyn std::error::Error>> {
+    let span = Span::<Interbase>::try_new(10, 20)?;
+    let interval = Interval::try_new("seq0", "+", span.clone())?;
+    let coordinate = Coordinate::<Interbase>::try_new("seq0", "+", 15)?;
+    let entity = Position::<Base>::try_new(15)?;
+
+    assert_eq!(
+        interval.contains_coordinate(&coordinate),
+        span.contains_position(coordinate.position())
+    );
+    assert_eq!(
+        interval.contains_entity(&Coordinate::try_new("seq0", "+", 15)?),
+        span.contains_entity(&entity)
+    );
+    assert_eq!(interval.count_entities(), span.count_entities());
+    assert_eq!(
+        interval.coordinate_offset(&coordinate),
+        span.position_offset(coordinate.position())
+    );
+    assert_eq!(
+        interval
+            .coordinate_at_offset(5)
+            .map(|coordinate| coordinate.into_position()),
+        span.position_at_offset(5)
+    );
+
+    let operand_span = Span::<Interbase>::try_new(15, 25)?;
+    let operand = Interval::try_new("seq0", "+", operand_span.clone())?;
+    let clamped = interval.clone().clamp(operand)?;
+
+    assert_eq!(clamped.span(), &span.clone().clamp(operand_span)?);
+
+    let reversed = interval.reverse_complement();
+    assert_eq!(reversed.strand(), Strand::Negative);
+    assert_eq!(reversed.span(), &span.reversed());
 
     Ok(())
 }

--- a/omics-coordinate/tests/spans.rs
+++ b/omics-coordinate/tests/spans.rs
@@ -1,0 +1,129 @@
+#![expect(missing_docs, reason = "integration tests do not need crate docs")]
+
+use omics_coordinate::Position;
+use omics_coordinate::Span;
+use omics_coordinate::span::Direction;
+use omics_coordinate::system::Base;
+use omics_coordinate::system::Interbase;
+
+#[test]
+fn preserves_all_endpoint_directions() -> Result<(), Box<dyn std::error::Error>> {
+    let ascending = Span::<Interbase>::try_new(10, 20)?;
+    let stationary = Span::<Interbase>::try_new(10, 10)?;
+    let descending = Span::<Interbase>::try_new(20, 10)?;
+
+    assert_eq!(ascending.direction(), Direction::Ascending);
+    assert_eq!(stationary.direction(), Direction::Stationary);
+    assert_eq!(descending.direction(), Direction::Descending);
+    assert_eq!(descending.reversed(), ascending);
+
+    Ok(())
+}
+
+#[test]
+fn keeps_coordinate_system_semantics() -> Result<(), Box<dyn std::error::Error>> {
+    let base = Span::<Base>::try_new(10, 10)?;
+    let interbase = Span::<Interbase>::try_new(10, 10)?;
+
+    assert!(!base.is_empty());
+    assert_eq!(base.count_entities(), 1);
+    assert!(interbase.is_empty());
+    assert_eq!(interbase.count_entities(), 0);
+    assert!(Span::<Base>::try_new(0, 1).is_err());
+
+    Ok(())
+}
+
+#[test]
+fn parses_and_displays_directed_spans() -> Result<(), Box<dyn std::error::Error>> {
+    let span = "20-10".parse::<Span<Interbase>>()?;
+
+    assert_eq!(span.direction(), Direction::Descending);
+    assert_eq!(span.to_string(), "20-10");
+
+    Ok(())
+}
+
+#[test]
+fn converts_from_typed_positions() {
+    let start = Position::<Interbase>::new(20);
+    let end = Position::<Interbase>::new(10);
+    let span = Span::from((start, end));
+
+    assert_eq!(span.into_positions(), (start, end));
+}
+
+#[test]
+fn contains_positions_in_both_directions() -> Result<(), Box<dyn std::error::Error>> {
+    let ascending = Span::<Interbase>::try_new(10, 20)?;
+    let descending = Span::<Interbase>::try_new(20, 10)?;
+
+    assert!(ascending.contains_position(&Position::<Interbase>::new(10)));
+    assert!(ascending.contains_position(&Position::<Interbase>::new(15)));
+    assert!(ascending.contains_position(&Position::<Interbase>::new(20)));
+    assert!(!ascending.contains_position(&Position::<Interbase>::new(9)));
+    assert!(!ascending.contains_position(&Position::<Interbase>::new(21)));
+
+    assert!(descending.contains_position(&Position::<Interbase>::new(20)));
+    assert!(descending.contains_position(&Position::<Interbase>::new(15)));
+    assert!(descending.contains_position(&Position::<Interbase>::new(10)));
+    assert!(!descending.contains_position(&Position::<Interbase>::new(9)));
+    assert!(!descending.contains_position(&Position::<Interbase>::new(21)));
+
+    Ok(())
+}
+
+#[test]
+fn contains_entities_with_base_semantics() -> Result<(), Box<dyn std::error::Error>> {
+    let ascending = Span::<Base>::try_new(10, 20)?;
+    let descending = Span::<Base>::try_new(20, 10)?;
+
+    assert!(!ascending.contains_entity(&Position::<Base>::try_new(9)?));
+    assert!(ascending.contains_entity(&Position::<Base>::try_new(10)?));
+    assert!(ascending.contains_entity(&Position::<Base>::try_new(15)?));
+    assert!(ascending.contains_entity(&Position::<Base>::try_new(20)?));
+    assert!(!ascending.contains_entity(&Position::<Base>::try_new(21)?));
+
+    assert!(!descending.contains_entity(&Position::<Base>::try_new(9)?));
+    assert!(descending.contains_entity(&Position::<Base>::try_new(10)?));
+    assert!(descending.contains_entity(&Position::<Base>::try_new(15)?));
+    assert!(descending.contains_entity(&Position::<Base>::try_new(20)?));
+    assert!(!descending.contains_entity(&Position::<Base>::try_new(21)?));
+
+    Ok(())
+}
+
+#[test]
+fn contains_entities_with_interbase_traversal_semantics() -> Result<(), Box<dyn std::error::Error>>
+{
+    let ascending = Span::<Interbase>::try_new(10, 20)?;
+    let stationary = Span::<Interbase>::try_new(10, 10)?;
+    let descending = Span::<Interbase>::try_new(20, 10)?;
+
+    assert!(!ascending.contains_entity(&Position::<Base>::try_new(10)?));
+    assert!(ascending.contains_entity(&Position::<Base>::try_new(11)?));
+    assert!(ascending.contains_entity(&Position::<Base>::try_new(15)?));
+    assert!(ascending.contains_entity(&Position::<Base>::try_new(20)?));
+    assert!(!ascending.contains_entity(&Position::<Base>::try_new(21)?));
+
+    assert!(!stationary.contains_entity(&Position::<Base>::try_new(10)?));
+
+    assert!(!descending.contains_entity(&Position::<Base>::try_new(10)?));
+    assert!(descending.contains_entity(&Position::<Base>::try_new(11)?));
+    assert!(descending.contains_entity(&Position::<Base>::try_new(15)?));
+    assert!(descending.contains_entity(&Position::<Base>::try_new(20)?));
+    assert!(!descending.contains_entity(&Position::<Base>::try_new(21)?));
+
+    Ok(())
+}
+
+#[test]
+fn exposes_system_aliases() -> Result<(), Box<dyn std::error::Error>> {
+    let base = omics_coordinate::span::base::Span::try_new(10, 12)?;
+    let interbase = omics_coordinate::span::interbase::Span::try_new(10, 12)?;
+
+    assert_eq!(base.start().get(), 10);
+    assert_eq!(interbase.end().get(), 12);
+
+    Ok(())
+}

--- a/omics-variation/src/small.rs
+++ b/omics-variation/src/small.rs
@@ -59,14 +59,13 @@ pub enum Kind {
 pub(crate) fn base_interval(start: &Coordinate<Base>, len: usize) -> Option<Interval<Base>> {
     let span = Number::try_from(len.checked_sub(1)?).ok()?;
     let end = start.clone().into_move_forward(span)?;
-    Interval::try_new(start.clone(), end).ok()
+    Interval::try_from((start.clone(), end)).ok()
 }
 
 /// Builds a zero-width interbase interval at a boundary coordinate.
 pub(crate) fn interbase_interval(coordinate: &Coordinate<Interbase>) -> Interval<Interbase> {
-    // SAFETY: an interbase interval whose start equals its end is always
-    // valid.
-    Interval::try_new(coordinate.clone(), coordinate.clone()).unwrap()
+    // SAFETY: equal endpoints share context and form a stationary span.
+    Interval::try_from((coordinate.clone(), coordinate.clone())).unwrap()
 }
 
 /// Builds a zero-width interbase interval immediately before a base coordinate.


### PR DESCRIPTION
Coordinate geometry previously existed only inside `Interval`, coupling endpoint operations to contig and strand context and making boundary-only or unlocalized ranges awkward to represent.

This added a coordinate-system-typed `Span<S>` that preserved endpoint order and derived ascending, stationary, or descending direction, including empty interbase spans for boundary events. `Interval<S>` now composed a contig, strand, and span while delegating geometry; this intentionally changed `Interval::try_new` to accept `(contig, strand, span)` and replaced negatively-sized interval errors with typed direction mismatches.

Before submitting this PR, please make sure:

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see [\"keep a changelog\"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[\"keep a changelog\"]: https://keepachangelog.com/en/1.1.0/